### PR TITLE
Update CI to Handle No `dev` Branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -145,7 +145,7 @@ jobs:
       - sbom
       - lint
       - style
-    if: ${{ endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release') }}
+    if: ${{ (endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/')) || github.event.pull_request.merged ) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -155,6 +155,37 @@ jobs:
       - name: Get RC Version
         id: lasttag
         run: |
+          COMMIT="${{github.sha}}"
+          if ${{contains(github.head_ref, 'release/')}}; then
+            V="${{github.head_ref}}"
+            V="${V#release/}"
+          else
+            V="$(npm pkg get version)"
+            V=v${V//\"/} #remove '"'s
+          fi
+
+          # Check to see if the version tag already exists
+          # If it does, print a message and exit with an error code
+          if [ $(git tag --list "$V") ]; then
+            echo "Version tag already exists. Did you bump the version number?"
+            exit 1
+          fi
+
+          # Create an RC release if
+          # 1) This PR is a release branch that hasn't been merged to main.
+          # 2) This is a feature branch being merged into the main branch.
+          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release/')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release/'))}}; then
+            V="${V}-$(git tag --list ${V}* | wc -l)"
+          fi
+
+          CL=${V#v}
+          CL=${CL%-*}
+
+          echo "version=${V}" >> $GITHUB_OUTPUT
+          echo "cl_version=${CL}" >> $GITHUB_OUTPUT
+          echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
+
+
           COMMIT="${{github.sha}}"
           V="${{github.head_ref}}"
           V="${V#release/}"
@@ -203,7 +234,7 @@ jobs:
 
             ${{steps.changelog.outputs.description}}
 
-          prerelease: ${{! github.event.pull_request.merged}}
+          prerelease: ${{ (! github.event.pull_request.merged) || (github.event.pull_request.merged && ! contains(github.head_ref, 'release/')) }}
           commit: ${{steps.lasttag.outputs.commit}}
           makeLatest: true
           tag: ${{steps.lasttag.outputs.version}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -185,21 +185,6 @@ jobs:
           echo "cl_version=${CL}" >> $GITHUB_OUTPUT
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
 
-
-          COMMIT="${{github.sha}}"
-          V="${{github.head_ref}}"
-          V="${V#release/}"
-
-          if ${{! github.event.pull_request.merged}}; then
-            V="${V}-$(git tag --list ${V}* | wc -l)"
-          fi
-
-          CL=${V#v}
-          CL=${CL%-*}
-
-          echo "version=${V}" >> $GITHUB_OUTPUT
-          echo "cl_version=${CL}" >> $GITHUB_OUTPUT
-          echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
       - run: 'git tag --list ${V}*'
       - name: Get Artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,7 +161,9 @@ jobs:
             V="${V#release/}"
           else
             V="$(npm pkg get version)"
-            V=v${V//\"/} #remove '"'s
+            echo "Extracted Version: $V"
+            V="$(echo v"$V" | sed 's/\"//g')"
+            echo "Cleaned up Version: $V"
           fi
 
           # Check to see if the version tag already exists
@@ -176,6 +178,7 @@ jobs:
           # 2) This is a feature branch being merged into the main branch.
           if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release/')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release/'))}}; then
             V="${V}-$(git tag --list ${V}* | wc -l)"
+            echo "RC Version: $V"
           fi
 
           CL=${V#v}

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -3,7 +3,7 @@ name: Veracode Scan
 on:
   push:
     branches:
-      - dev
+      - main
   schedule:
     - cron: 0 0 * * sun
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [0.15.1]
+
+### Changed
+- Nothing yet
+
 ## [0.15.0]
 
 ### Fixed
@@ -69,7 +74,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Feature to retrieve TSP-Link network details
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.15.1
 [0.15.0]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.15.0
 [0.14.1]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.14.1
 [0.13.2]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.13.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tsp-toolkit",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tsp-toolkit",
-            "version": "0.15.0",
+            "version": "0.15.1",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -30,7 +30,7 @@
                 "@types/mocha": "^9.1.1",
                 "@types/node": "^14.18.63",
                 "@types/node-fetch": "^2.6.11",
-                "@types/vscode": "^1.87.0",
+                "@types/vscode": "^1.75.0",
                 "@typescript-eslint/eslint-plugin": "^5.62.0",
                 "@typescript-eslint/parser": "^5.62.0",
                 "@vscode/vsce": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Tektronix",
     "displayName": "[Beta] Keithley TSP Toolkit",
     "description": "VSCode extension for Keithley Instruments' Test Script Protocol",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "icon": "./resources/TSP_Toolkit_128x128.png",
     "galleryBanner": {
         "color": "#EEEEEE",


### PR DESCRIPTION
To simplify the release workflow, the team has decided to remove the `dev` branch. This change requires a few changes to the CI system for all projects.

1. For every feature-branch pull request the is merged to `main`, create an appropriately versioned RC release (a tag, a GitHub release, plus any packaging) with the version indicated by the project's manifest file followed by a `-N`, where `N` is an incrementing number based on the number of RC tags for that release already in existence.
2. If the branch merging into `main` is a release branch, create an RC for every push to that branch with the version indicated by the release branch name followed by a `-N`, where `N` is an incrementing number based on the number of RC tags for that release already in existence.
3. If a pull request is merged to `main` from a release branch, create a full release with the version number indicated in the release branch name.