### PR TITLE
Remove the Schedule from Veracode Workflow

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: 0 0 * * sun
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the schedule from the Veracode workflow since each run is based on the hash of the repo contents.