### PR TITLE
Correct Extension Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
-## [Unreleased]
+## [0.15.3]
+
+### Fixed
+
+- Corrected extension description
+
+## [0.15.2]
 
 ### Fixed
 - Removed debugger related code from package.json (TSP-436)
@@ -87,7 +93,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Feature to retrieve TSP-Link network details
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit/compare/v0.15.3...HEAD
+[0.15.3]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.15.3
+[0.15.2]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.15.2
 [0.15.1]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.15.1
 [0.15.0]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.15.0
 [0.14.1]: https://github.com/tektronix/tsp-toolkit/releases/tag/v0.14.1

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ scripts on TSP-enabled Keithley instruments. The extension includes command-set 
 syntax error detection and code navigation (provided by [sumneko.lua][sumneko]) as well as
 code-completion suggestions, inline help, and TSP command documentation.
 
+## Demo Video
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/d1jsgy6Dslc?si=oPrUgdM5yp-ykcIh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Installed Extensions
 
 Keithley TSP Toolkit will automatically install the [sumneko.lua][sumneko]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tsp-toolkit",
-    "version": "0.15.1",
+    "version": "0.15.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tsp-toolkit",
-            "version": "0.15.1",
+            "version": "0.15.3",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "tsp-toolkit",
     "publisher": "Tektronix",
     "displayName": "[Beta] Keithley TSP Toolkit",
-    "description": "VSCode extension for Keithley Instruments' Test Script Protocol",
-    "version": "0.15.1",
+    "description": "VSCode extension for Keithley Instruments' Test Script Processor",
+    "version": "0.15.3",
     "icon": "./resources/TSP_Toolkit_128x128.png",
     "galleryBanner": {
         "color": "#EEEEEE",


### PR DESCRIPTION
The extension description defines TSP as `Test Script Protocol` when it should be `Test Script Processor`.