### PR TITLE
Remove Colon from Hard-coded Port Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Corrected extension description
+- Remove `:` from port number
 
 ## [0.15.2]
 

--- a/src/resourceManager.ts
+++ b/src/resourceManager.ts
@@ -409,7 +409,7 @@ export class ConnectionHelper {
                 .split("</SerialNumber>")[0]
                 .split("<SerialNumber>")[1]
             // const portSplit = body.split("::SOCKET")[0].split("::")
-            const portNumber = ":5025"
+            const portNumber = "5025"
             // if (portSplit.length > 0) {
             //     portNumber = ":" + portSplit[portSplit.length - 1]
             // }


### PR DESCRIPTION
The port number we currently "get" is from a hard-coded port value. This value is never used anywhere from what I can tell. It is safe to remove the colon. 