### PR TITLE
Adding tsplink nodes in config.tsp.json file does not load definitions for added node lua table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Corrected extension description
 - Remove `:` from port number
+- Adding tsplink nodes in config.tsp.json file does not load definitions for added node lua table
 
 ## [0.15.2]
 

--- a/src/workspaceManager.ts
+++ b/src/workspaceManager.ts
@@ -171,6 +171,40 @@ function disableDiagnosticForLibraryFiles(
 }
 
 /**
+ * Configure empty list to Lua.workspace.ignoreDir
+ * @param workspace_path workspace folder path
+ */
+function setEmptyLuaWorkspaceIgnoreDirList(
+    workspace_path: vscode.WorkspaceFolder
+) {
+    const configuration = vscode.workspace.getConfiguration(
+        undefined,
+        workspace_path.uri
+    )
+    configuration
+        .update(
+            "Lua.workspace.ignoreDir",
+            [],
+            vscode.ConfigurationTarget.WorkspaceFolder
+        )
+        .then(
+            () => {
+                // Configuration updated successfully
+                void vscode.window.showInformationMessage(
+                    "Lua.workspace.ignoreDir configuration updated"
+                )
+            },
+            (error) => {
+                // Error occurred while updating the configuration
+                void vscode.window.showInformationMessage(
+                    "Failed to update Lua.workspace.ignoreDir configuration:",
+                    error
+                )
+            }
+        )
+}
+
+/**
  * Iterate over workspace folder to find file with .tsp extension
  */
 export async function processWorkspaceFolders() {
@@ -181,6 +215,7 @@ export async function processWorkspaceFolders() {
             if (await processFiles(folderPath)) {
                 updateFileAssociations()
                 disableDiagnosticForLibraryFiles(folder)
+                setEmptyLuaWorkspaceIgnoreDirList(folder)
                 createTspFileFolder(folderPath)
             }
         }


### PR DESCRIPTION
Default value of the Lua.workspace.ignoreDir configuration list contains .vscode folder 
Since .vscode folder stores generated node table details its getting ignored by default

Making Lua.workspace.ignoreDir configuration as empty list for workspace setting 