### PR TITLE
Add back in the step that auto-publishes to the marketplace

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
           npm install --devDependencies
-          # npx vsce publish --packagePath extension/*.vsix
+          npx vsce publish --packagePath extension/*.vsix
         env:
           VSCE_PAT: ${{secrets.VSCE_PAT}}
 


### PR DESCRIPTION
In the v0.16.1 release, the version was automatically pushed before the PR was closed (this was expected, it was part of testing). The step that was added back in as part of this PR was removed to prevent naming conflicts. 

The publish step will only run after a successful merge from a release branch.