### PR TITLE
Improvement: "Open Terminal IP" should just open the terminal,

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug.yml
@@ -47,7 +47,7 @@ body:
       description: List the steps you took to exhibit the issue.
       placeholder: |
         Example:
-          1. Open Command Pallette and enter "TSP: Open Terminal"
+          1. Open Command Pallette and enter "TSP: Connect"
           2. Select "New Connection"
           3. Type in IP address for 2450
           4. After connection, enter `print("some string that breaks the terminal")`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ following commands:
 
 | Command                          | Description                                                                         | Shortcut                                        |
 |:---------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------|
-| TSP: Open Terminal               | Opens a new terminal session to an instrument (be sure to close with `.exit`, see the [Known Issues](#known-issues) section below) |                                                 |
+| TSP: Connect               | Opens a new terminal session to an instrument (be sure to close with `.exit`, see the [Known Issues](#known-issues) section below) |                                                 |
 | TSP: Send Script to Terminal     | Sends the script in the current editor window to the currently connected instrument |                                                 |
 
 To see all available Keithley TSP Toolkit commands, open the Command Pallette and type `TSP`.
@@ -76,7 +76,7 @@ then it is possible to have TSP Toolkit automatically configure your project for
 
 1. Open any workspace folder in VSCode
 2. If your workspace folder does not already contain one, create a .tsp (for example `my-tsp-file.tsp`)
-3. Connect to your instrument using the discovery pane or the `TSP: Open Terminal` command.
+3. Connect to your instrument using the discovery pane or the `TSP: Connect` command.
 4. Right-click on the `.vscode/tspConfig` folder
 5. Select "Fetch TSP-Link Nodes for Connected Instrument"
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
             },
             {
                 "command": "tsp.openTerminalIP",
-                "title": "Open Terminal",
+                "title": "Connect",
                 "category": "TSP"
             },
             {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "commands": [
             {
                 "command": "tsp.openTerminal",
-                "title": "Open Terminal",
+                "title": "Connect",
                 "category": "TSP"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -477,7 +477,13 @@ async function startRename(def: unknown): Promise<void> {
 function connectCmd(def: object) {
     const [res1, res2, res3] = _instrExplorer.fetchConnectionArgs(def)
     //console.log(res1, res2, res3)
-    void connect(res1, res2, res3)
+    //void connect(res1, res2, res3)
+
+    if (_activeConnectionManager?.connectionRE.test(res1)) {
+        void createTerminal(res1, res3)
+    } else {
+        void vscode.window.showErrorMessage("Unable to connect.")
+    }
 }
 
 const base_api = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -475,12 +475,11 @@ async function startRename(def: unknown): Promise<void> {
 }
 
 function connectCmd(def: object) {
-    const [res1, res2, res3] = _instrExplorer.fetchConnectionArgs(def)
-    //console.log(res1, res2, res3)
-    //void connect(res1, res2, res3)
+    const [connection_str, model_serial] =
+        _instrExplorer.fetchConnectionArgs(def)
 
-    if (_activeConnectionManager?.connectionRE.test(res1)) {
-        void createTerminal(res1, res3)
+    if (_activeConnectionManager?.connectionRE.test(connection_str)) {
+        void createTerminal(connection_str, model_serial)
     } else {
         void vscode.window.showErrorMessage("Unable to connect.")
     }

--- a/src/instruments.ts
+++ b/src/instruments.ts
@@ -1341,18 +1341,20 @@ export class InstrumentsExplorer {
         }
     }
 
-    public fetchConnectionArgs(item: object): [string, boolean, string?] {
+    public fetchConnectionArgs(
+        item: object
+    ): [connection_str: string, model_serial?: string] {
         const resNode = item as IOInstrNode
         if (resNode != undefined) {
             const conn_name =
                 resNode.label + "@" + resNode.FetchConnectionAddr()
             if (resNode.FetchInstrIOType() == IoType.Lan) {
-                return [conn_name, true]
+                return [conn_name]
             } else {
-                return [conn_name, true, resNode.fetchModelSerial()]
+                return [conn_name, resNode.fetchModelSerial()]
             }
         }
-        return ["", false]
+        return [""]
     }
 
     private async upgradeFirmware(_e: unknown) {


### PR DESCRIPTION
"Open Terminal IP" should just open the terminal, not just in the command palette
renaming "Open Terminal" to "Connect"