### PR TITLE
Add VISA Resource String Support When Adding Instruments

### DIFF
--- a/src/communicationmanager.ts
+++ b/src/communicationmanager.ts
@@ -113,8 +113,9 @@ export class CommunicationManager {
             const res = await vscode.window.showInputBox(options)
             if (res?.toUpperCase() === "YES") {
                 const options: vscode.InputBoxOptions = {
-                    prompt: "Enter instrument IP in <insName>@<IP> format",
-                    validateInput: this._connHelper.instrIPValidator,
+                    prompt: "Enter instrument IP address or VISA resource string",
+                    validateInput:
+                        this._connHelper.instrConnectionStringValidator,
                 }
                 const Ip = await vscode.window.showInputBox(options)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -378,8 +378,8 @@ async function pickConnection(connection_info?: string): Promise<void> {
 
     if (connection_info !== undefined) {
         const options: vscode.InputBoxOptions = {
-            prompt: "Enter instrument IP in <insName>@<IP> format",
-            validateInput: _connHelper.instrIPValidator,
+            prompt: "Enter instrument IP address or VISA resource string",
+            validateInput: _connHelper.instrConnectionStringValidator,
         }
         const Ip = await vscode.window.showInputBox(options)
         if (Ip === undefined) {
@@ -414,9 +414,10 @@ async function pickConnection(connection_info?: string): Promise<void> {
             quickPick.busy = true
             try {
                 // Validate connection string
-                const validationResult = _connHelper.instrIPValidator(
-                    selectedItem.label,
-                )
+                const validationResult =
+                    _connHelper.instrConnectionStringValidator(
+                        selectedItem.label,
+                    )
                 if (validationResult) {
                     throw new Error(validationResult)
                 }

--- a/src/resourceManager.ts
+++ b/src/resourceManager.ts
@@ -245,7 +245,7 @@ export class KicProcessMgr {
         //return new ConnectionDetails("", connAddr, connType)
         const options: vscode.InputBoxOptions = {
             prompt: "Enter instrument IP in <IP> format",
-            validateInput: this._connHelper.instrIPValidator,
+            validateInput: this._connHelper.instrConnectionStringValidator,
         }
         const ip = await vscode.window.showInputBox(options)
         if (ip === undefined) {
@@ -441,19 +441,24 @@ export class ConnectionHelper {
             ip,
         )
     }
-    public instrIPValidator = (val: string) => {
-        let ip = val
+    public VisaResourceStringTest(val: string): boolean {
+        return /^(visa:\/\/.*\/)?((TCPIP|USB|GPIB|ASRL|FIREWIRE|GPIB-VXI|PXI|VXI)\d*)::.*/.test(
+            val,
+        )
+    }
+    public instrConnectionStringValidator = (val: string) => {
+        let conn_str = val
         if (val.split("@").length > 1) {
-            ip = val.split("@")[1]
+            conn_str = val.split("@")[1]
         }
-        if (this.IPTest(ip) == false) {
-            return "Enter proper IPv4 address"
+        if (!this.IPTest(conn_str) && !this.VisaResourceStringTest(conn_str)) {
+            return "Enter proper IPv4 address or VISA resource string"
         }
 
-        void this.getModelAndSerialNumber(ip).then((msn) => {
+        void this.getModelAndSerialNumber(conn_str).then((msn) => {
             if (msn != undefined) {
                 void vscode.window.showInformationMessage(
-                    ip +
+                    conn_str +
                         ": Found instrument model " +
                         msn.model +
                         " with S/N: " +


### PR DESCRIPTION
- Modify prompt to include reference to VISA resource string
- Modify RegEx to support any VISA resource string
- NOTE: New RegEx does not ensure VISA resource strings are correct, but checks for beginning of resource string and assumes the rest is correct