### PR TITLE
TSP-839 Fix issue with visa connection model and serial number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [1.0.0]
+
+### Fixed
+
+- When entering only visa instrument address, connection is saved with correct model and serial number (TSP-839)
 
 ## [0.18.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
-## [1.0.0]
-
-### Fixed
-
-- When entering only visa instrument address, connection is saved with correct model and serial number (TSP-839)
-
 ## [0.18.2]
 
 ### Added
@@ -38,6 +32,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - **tsp-toolkit-kic-cli**: Only call `readSTB` after a command or script is written to
   the instrument
+- When entering only visa instrument address, connection is saved with correct model and serial number (TSP-839)
 
 ## [0.18.1]
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,10 +96,6 @@ export function createTerminal(
     } else {
         Log.debug("Connection type was determined to be VISA", LOGLOC)
         //VISA
-        //This only works if selected from Instrument discovery
-        // if (name == "") {
-        //     name = FriendlyNameMgr.generateUniqueName(IoType.Visa, model_serial)
-        // }
         res = _activeConnectionManager?.createTerminal(
             name,
             IoType.Visa,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,9 +77,9 @@ export function createTerminal(
     } else {
         //VISA
         //This only works if selected from Instrument discovery
-        if (name == "") {
-            name = FriendlyNameMgr.generateUniqueName(IoType.Visa, model_serial)
-        }
+        // if (name == "") {
+        //     name = FriendlyNameMgr.generateUniqueName(IoType.Visa, model_serial)
+        // }
         res = _activeConnectionManager?.createTerminal(
             name,
             IoType.Visa,

--- a/src/resourceManager.ts
+++ b/src/resourceManager.ts
@@ -80,26 +80,28 @@ export class FriendlyNameMgr {
      * @returns - unique friendly name for given instrument
      */
     public static generateUniqueName(
-        io_type: IoType,
+        conn_type: string,
         model_serial: string | undefined,
     ): string {
         let unique_name = ""
         let found = false
+        const io_type: IoType = FriendlyNameMgr.getIoType(conn_type)
         const connections: Array<InstrInfo> =
             vscode.workspace.getConfiguration("tsp").get("savedInstruments") ??
             []
 
         if (connections.length > 0) {
-            connections.forEach((instr) => {
+            for (let i = 0; i < connections.length; i++) {
+                const instr = connections[i]
                 if (
                     io_type === instr.io_type &&
                     model_serial == instr.model + "#" + instr.serial_number
                 ) {
                     unique_name = instr.friendly_name
                     found = true
-                    return
+                    break
                 }
-            })
+            }
         }
 
         if (!found) {
@@ -114,6 +116,18 @@ export class FriendlyNameMgr {
             unique_name = uniqueString
         }
         return unique_name
+    }
+
+    private static getIoType(conn_type: string) {
+        let io_type: IoType
+        if (conn_type === "usb") {
+            io_type = IoType.Usb
+        } else if (conn_type === "lan") {
+            io_type = IoType.Lan
+        } else {
+            io_type = IoType.Visa
+        }
+        return io_type
     }
 
     /**
@@ -327,7 +341,7 @@ export class KicCell extends EventEmitter {
 
         if (name == "") {
             verified_name = FriendlyNameMgr.generateUniqueName(
-                IoType.Lan,
+                connType,
                 _info.model + "#" + _info.serial_number,
             )
             name = verified_name


### PR DESCRIPTION
If the user doesn't provide a connection name, a new name is generated within initialiseComponents() function using
the function "FriendlyNameMgr.generateUniqueName()". This flow is common to both Lan and Visa connection.