### PR TITLE
TSP-839 Fix issue with naming of instrument connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Fix issue where connecting to an instrument can fail with a mysterious error message
+- Connection name needs to be same in Instruments pane, terminal and quick pick for a given instrument connection (TSP-839)
 
 ## [0.18.2]
 


### PR DESCRIPTION
When we connect to an instrument, the information (io_type, instr_address, model, serial_number, friendly_name etc.) is saved to settings.json. Any item in Instruments pane (discovered or saved) is initially created with label <model#serial_number>. For saved instruments we need to update this to any connection_name if specified by user and this information is fetched from settings.json. Since the settings.json was not updated correctly due to not awaiting, the Instruments pane showed wrong label as compared to terminal name. This is fixed by awaiting when settings.json file is updated.