### PR TITLE
Fixes for Instruments Staying in Remote after Closing Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   clearing it so it can be printed when opening the terminal
 - Added progress indication to connection notification
 
+### Changed
+
+- Discover will use LXI identification page to get instrument information instead of `*IDN?`
+
 ### Fixed
 
 - Fixed Readme links and worked around markdown parser error
+- Close and reset instrument connections when extension is deactivated
 
 
 ## [1.0.0]

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
                 "vscode": "^1.92.0"
             },
             "optionalDependencies": {
-                "@tektronix/kic-cli-darwin-arm64": "0.19.0-0",
-                "@tektronix/kic-cli-linux-x64": "0.19.0-0",
-                "@tektronix/kic-cli-win32-x64": "0.19.0-0"
+                "@tektronix/kic-cli-darwin-arm64": "0.19.0-2",
+                "@tektronix/kic-cli-linux-x64": "0.19.0-2",
+                "@tektronix/kic-cli-win32-x64": "0.19.0-2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -112,15 +112,15 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.17.0.tgz",
-            "integrity": "sha512-62Vv8nC+uPId3j86XJ0WI+sBf0jlqTqPUFCBNrGtlaUeQUIXWV/D8GE5A1d+Qx8H7OQojn2WguC8kChD6v0shA==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.18.0.tgz",
+            "integrity": "sha512-QSoGUp4Eq/gohEFNJaUOwTN7BCc2nHTjjbm75JT0aD7W65PWM1H/tItz0GsABn22uaKyGxiMhWQLt2r+FGU89Q==",
             "dev": true,
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.8.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.9.0",
+                "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.0",
@@ -214,9 +214,9 @@
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.0.tgz",
-            "integrity": "sha512-oww0oJTOOvPKTVXqVyxfcFVjExQKYEkKR5KM0cTG3jnzt6u/MRMx8XaK49L/bxV35r9sCHQFjNlEShad9qGSYA==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.1.tgz",
+            "integrity": "sha512-1NEFpTmMMT2A7RnZuvRl/hUmJU+GLPjh+ShyIqPktG2PvSd2yvPnzGd/BxIBAAvJG5nr9lH4oYcQXepDbaE7fg==",
             "dev": true,
             "dependencies": {
                 "@azure/msal-common": "14.16.0",
@@ -944,9 +944,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-darwin-arm64": {
-            "version": "0.19.0-0",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-darwin-arm64/0.19.0-0/bcb670613090cf572d34eaed7adb00064d86daaa",
-            "integrity": "sha512-rNTGrLJ3UkPp3aEaLiFNeylOVwbbsgTNovsDjqaroI2zcTEr6QYH9De3CBkDR470FMhkwrLmB9FauwXdssYr5g==",
+            "version": "0.19.0-2",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-darwin-arm64/0.19.0-2/6ed1d04b44526adb903fc677fead475c22f0ac76",
+            "integrity": "sha512-EI0jOZ0Mmr9TEw1KsL4lRwjU35G1PUe41UAHu0Jt/VepwQwja7Ol9dqUBuI12wGtnq0ChcBnZVVV7qA/l3ILkA==",
             "cpu": [
                 "arm64"
             ],
@@ -962,9 +962,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-linux-x64": {
-            "version": "0.19.0-0",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-linux-x64/0.19.0-0/64257f6a1300e37b03ba6568bbdce07cb40cf745",
-            "integrity": "sha512-+AEqIp7n4OV/DgwMTCyGSPmgHn5Q4SOEdboCZgS4WWPOpvL7//F1DDrxdcHdMnokPKWKuBOBtcrDQaN5veleXg==",
+            "version": "0.19.0-2",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-linux-x64/0.19.0-2/15d49ccba07350098ef356dccddbdedffd7438f2",
+            "integrity": "sha512-CfHdRBhq8dQeka7o14YrbGaEGAZuCvf3W9eroXBTRtdYwfyPRO/ym1jUrYVF7sYP3gKDdOgJ4Juon+mVMnNQgw==",
             "cpu": [
                 "x64"
             ],
@@ -980,9 +980,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-win32-x64": {
-            "version": "0.19.0-0",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-win32-x64/0.19.0-0/3501ad9222a40e046a28561b99d11b958258be0d",
-            "integrity": "sha512-LQDQYcikajhS6yINANLDnjBnSJZjQqWIcYBQHIHRjfDb1XEev/1qfABr13J1Ps+fvAcBJh45F0t47qXJk6kYCg==",
+            "version": "0.19.0-2",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-win32-x64/0.19.0-2/f2170a0f54fbb6540a97ffd2a725212b084a5889",
+            "integrity": "sha512-66z6XfRnjhenD4L6MXFbRzKi7x7S5+P3MS5I2WINKdEsGXmgLEQ8Z7xjDxyf3/qVKaMXnk/Kag4iWcJm9YsyWg==",
             "cpu": [
                 "x64"
             ],
@@ -2688,9 +2688,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.56",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.56.tgz",
-            "integrity": "sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw==",
+            "version": "1.5.58",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.58.tgz",
+            "integrity": "sha512-al2l4r+24ZFL7WzyPTlyD0fC33LLzvxqLCwurtBibVPghRGO9hSTl+tis8t1kD7biPiH/en4U0I7o/nQbYeoVA==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -2746,9 +2746,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-            "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+            "version": "1.23.4",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.4.tgz",
+            "integrity": "sha512-HR1gxH5OaiN7XH7uiWH0RLw0RcFySiSoW1ctxmD1ahTw3uGBtkmm/ng0tDU1OtYx5OK6EOL5Y6O21cDflG3Jcg==",
             "dev": true,
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
@@ -2766,7 +2766,7 @@
                 "function.prototype.name": "^1.1.6",
                 "get-intrinsic": "^1.2.4",
                 "get-symbol-description": "^1.0.2",
-                "globalthis": "^1.0.3",
+                "globalthis": "^1.0.4",
                 "gopd": "^1.0.1",
                 "has-property-descriptors": "^1.0.2",
                 "has-proto": "^1.0.3",
@@ -2782,10 +2782,10 @@
                 "is-string": "^1.0.7",
                 "is-typed-array": "^1.1.13",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
+                "object-inspect": "^1.13.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.5",
-                "regexp.prototype.flags": "^1.5.2",
+                "regexp.prototype.flags": "^1.5.3",
                 "safe-array-concat": "^1.1.2",
                 "safe-regex-test": "^1.0.3",
                 "string.prototype.trim": "^1.2.9",
@@ -6531,9 +6531,9 @@
             }
         },
         "node_modules/process-on-spawn": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-            "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+            "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
             "dev": true,
             "dependencies": {
                 "fromentries": "^1.2.0"
@@ -7985,9 +7985,9 @@
             "dev": true
         },
         "node_modules/undici": {
-            "version": "6.20.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
-            "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+            "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
             "engines": {
                 "node": ">=18.17"
             }

--- a/package.json
+++ b/package.json
@@ -489,9 +489,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/kic-cli-linux-x64": "0.19.0-0",
-        "@tektronix/kic-cli-win32-x64": "0.19.0-0",
-        "@tektronix/kic-cli-darwin-arm64": "0.19.0-0"
+        "@tektronix/kic-cli-linux-x64": "0.19.0-2",
+        "@tektronix/kic-cli-win32-x64": "0.19.0-2",
+        "@tektronix/kic-cli-darwin-arm64": "0.19.0-2"
     },
     "extensionDependencies": [
         "sumneko.lua"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,11 +265,17 @@ export function activate(context: vscode.ExtensionContext) {
 
 // Called when the extension is deactivated.
 export function deactivate() {
-    Log.info("Deactivating TSP Toolkit", {
-        file: "extensions.ts",
-        func: "deactivate()",
-    })
-    /* empty */
+    const LOGLOC = { file: "extensions.ts", func: "deactivate()" }
+    Log.info("Deactivating TSP Toolkit", LOGLOC)
+    Log.trace("Closing all kic executables", LOGLOC)
+    _kicProcessMgr.dispose().then(
+        () => {
+            Log.info("Deactivation complete", LOGLOC)
+        },
+        () => {
+            Log.error("Deactivation had errors.")
+        },
+    )
 }
 
 //Request the instrument to be reset


### PR DESCRIPTION
- **tsp-toolkit-kic-cli:** Bring in changes to not interrupt LAN instruments when discovered by VISA
- Close and reset instrument connections when extension is deactivated