### PR TITLE
Handling  dynamically creating blockType param constant for the node configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 - support dynamically creating enums for configured nodes
+- handling dynamically creating enums for trigger.model.setblock() command parameter
+
+### Fixed
+- making sure that node[N].execute(), node[N].getglobal() and node[N].setglobal() only visible in TSP-Link systems
 
 ## [1.1.0]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "tsp-toolkit",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tsp-toolkit",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@tektronix/keithley_instrument_libraries": "0.18.2",
+                "@tektronix/keithley_instrument_libraries": "0.18.4",
                 "@tektronix/web-help-documents": "0.18.0",
                 "@types/cheerio": "0.22.35",
                 "cheerio": "1.0.0",
@@ -936,9 +936,10 @@
             }
         },
         "node_modules/@tektronix/keithley_instrument_libraries": {
-            "version": "0.18.2",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/keithley_instrument_libraries/0.18.2/860bbc1efb5a34d27accf5afd2a0474a41342aee",
-            "integrity": "sha512-ozs/NoJhEeHUlnC3olnrsTQqDLybvLf/Tawo2V+Hni6r4UQz1GVLlYlOS7XZ5sy21FMZQSgNiOHFiPlvnpTaqQ==",
+            "version": "0.18.4",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/keithley_instrument_libraries/0.18.4/684d41c33b5b81d0446be02ca0008f0160c34b0a",
+            "integrity": "sha512-+wNASilMndUXmSOutQEZ/Ag6HPv2jM04XASpgcKWvuRjK7YHDWvYgYhu07IYMg3RruOaN5LlqVJS3IhLYpd+dA==",
+            "license": "ISC",
             "dependencies": {
                 "node-fetch": "^2.7.0"
             }

--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
         "typescript": "5.5.4"
     },
     "dependencies": {
-        "@tektronix/keithley_instrument_libraries": "0.18.3",
+        "@tektronix/keithley_instrument_libraries": "0.18.4",
         "@tektronix/web-help-documents": "0.18.0",
         "@types/cheerio": "0.22.35",
         "cheerio": "1.0.0",


### PR DESCRIPTION
trigger.model.setblock(blockNumber, blockType,...) command blockType parameter should be created dynamically for the configured nodes.

below command should available only in when nodes are connected in TSP-Link systems 
node[N].execute()
node[N].getglobal()
node[N].setglobal()

updating version and changelog file