### PR TITLE
Don't Create Settings if no TSP File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Major visual overhaul to the instruments pane
 
+### Fixed
+
+- Don't create a `.vscode` folder with `config.tsp.json` if the workspace folder does not
+  contain a `.tsp` file.
+
 ## [1.1.1]
 
 ### Added


### PR DESCRIPTION
Recursively check if a folder has a `.tsp` file before creating Lua settings