### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 
-- Added connection support for 5881-SRU and 5880-SRU
 - Optionally use `firmware.valid` attribute for applicable instruments to only run
   upgrade on valid firmware
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ for more information.
 - Due to limitations in instrument firmware, script names longer than 27 characters will
   be truncated to 27 characters. If multiple scripts have names that are the same up to
   the 27th character, the second script will overwrite the first.
+- Some instruments (2450, 2460, 2461, 2470, DAQ6500, DMM7510, 3706A, 707B, 708B) encounter
+  a fatal error if the trash can is used to close the connected terminal if the instrument
+  is connected via GPIB on VISA. Be sure to type `.exit` when connected to one of these
+  instruments over GPIB.
 - The list of instruments that support language features is limited to the following:
     - 2450
     - 2460

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
                 "vscode": "^1.92.0"
             },
             "optionalDependencies": {
-                "@tektronix/kic-cli-darwin-arm64": "0.19.3-3",
-                "@tektronix/kic-cli-linux-x64": "0.19.3-3",
-                "@tektronix/kic-cli-win32-x64": "0.19.3-3"
+                "@tektronix/kic-cli-darwin-arm64": "0.19.3",
+                "@tektronix/kic-cli-linux-x64": "0.19.3",
+                "@tektronix/kic-cli-win32-x64": "0.19.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1025,9 +1025,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-darwin-arm64": {
-            "version": "0.19.3-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-darwin-arm64/0.19.3-3/cdb62227bdd36b1b9ee022405a4a3d7b86de90eb",
-            "integrity": "sha512-5mLeJf8zSiU5AAFdfD/ZnbUO0chur8guVMaXPiD5/WQ/5BhJ5e3h7KPIcksPw66OndGQXlj8K1uZ6hycWZY/KA==",
+            "version": "0.19.3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-darwin-arm64/0.19.3/96ebd88b1f244d938c84ef0fff08eb3c0369fcbc",
+            "integrity": "sha512-ftT0D2nn2CSJ3+xZJJUokwszIzZmvQktMKRlRrSE6OnG303RRLizJbRDjFJH7UVWTqgXzvlCw3PG/zYJseHEAQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1043,9 +1043,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-linux-x64": {
-            "version": "0.19.3-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-linux-x64/0.19.3-3/eb9e749f26c3510ff27f4540ac7d7aed2e67818f",
-            "integrity": "sha512-afUZDy3ZJYnvE9kIh/XXj344ZnykT1i9sERLqZ0C0ad/RJ8PPIO4+Y+NhqWhfo+ie8BH+IMpin7mjSvGbAZnFQ==",
+            "version": "0.19.3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-linux-x64/0.19.3/89f96e72e2a1da0e13758acd1f2bae35df32f322",
+            "integrity": "sha512-yIn4Cu8WurDI3JN/cxy4TkZCvJQHiGxmtKxlsmprANnLD938HWnG6/QopdAYSwb6rbqwcSNr+eyVAXkYWr2yZA==",
             "cpu": [
                 "x64"
             ],
@@ -1061,9 +1061,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-win32-x64": {
-            "version": "0.19.3-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-win32-x64/0.19.3-3/5dfe3a513031ef93feccb4ecbacc2e4310ad4723",
-            "integrity": "sha512-WDOl6hjQH6IsjJvg2XNV8VCaWtbwDhwRFnRTbdnqkrKUmIFD0pPGh1GGROr1M2KGXxiOlOO1hP3J2iIQtbtdbw==",
+            "version": "0.19.3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-win32-x64/0.19.3/ce245a507037c4740a36dc21e746d17123c867af",
+            "integrity": "sha512-s4BjalQymApyG29tyHf6Fwo+44sf9P9bwCdRWWBubz+5F2kduEOKG1CMZRKtfo/o3tBK2bplnGzmkcdvqrlDHg==",
             "cpu": [
                 "x64"
             ],
@@ -2211,9 +2211,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001695",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-            "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+            "version": "1.0.30001696",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+            "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
             "dev": true,
             "funding": [
                 {
@@ -7778,9 +7778,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+            "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -452,9 +452,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/kic-cli-darwin-arm64": "0.19.3-3",
-        "@tektronix/kic-cli-linux-x64": "0.19.3-3",
-        "@tektronix/kic-cli-win32-x64": "0.19.3-3"
+        "@tektronix/kic-cli-darwin-arm64": "0.19.3",
+        "@tektronix/kic-cli-linux-x64": "0.19.3",
+        "@tektronix/kic-cli-win32-x64": "0.19.3"
     },
     "extensionDependencies": [
         "sumneko.lua"


### PR DESCRIPTION
- Major visual overhaul to the instruments pane
- Don't create a `.vscode` folder with `config.tsp.json` if the workspace folder does not contain a `.tsp` file.
- Optionally use `firmware.valid` attribute for applicable instruments to only run upgrade on valid firmware