### PR TITLE
(script-gen): npm package and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Fixed -- for any bug fixes.
     Security -- in case of vulnerabilities.
 -->
+## [1.3.1]
+
+### Fixed
+- (**tsp-toolkit-script-gen**) Sweep plot x axis ticks cutoff when number of points increase
+
 ## [1.3.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tsp-toolkit",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tsp-toolkit",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tektronix/keithley_instrument_libraries": "0.19.3",
@@ -55,9 +55,9 @@
                 "@tektronix/kic-cli-darwin-arm64": "0.21.0",
                 "@tektronix/kic-cli-linux-x64": "0.21.0",
                 "@tektronix/kic-cli-win32-x64": "0.21.0",
-                "@tektronix/script-gen-darwin-arm64": "0.1.0-7",
-                "@tektronix/script-gen-linux-x64": "0.1.0-7",
-                "@tektronix/script-gen-win32-x64": "0.1.0-7"
+                "@tektronix/script-gen-darwin-arm64": "0.1.0-8",
+                "@tektronix/script-gen-linux-x64": "0.1.0-8",
+                "@tektronix/script-gen-win32-x64": "0.1.0-8"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -1096,9 +1096,9 @@
             }
         },
         "node_modules/@tektronix/script-gen-darwin-arm64": {
-            "version": "0.1.0-7",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/script-gen-darwin-arm64/0.1.0-7/558b5c799f653c4c6c06125c5d86195ebff68046",
-            "integrity": "sha512-iUNFuU8C4tkMBVENkG+x3Y/35V8CdHftVfML0TKk5wjAiwbJOyQS5MycMJDxUGbIBoguWl/3Mkxf5LpcH/K6lg==",
+            "version": "0.1.0-8",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/script-gen-darwin-arm64/0.1.0-8/cb5a60d2f885fdb26c3e73044b2189ecd75bfa36",
+            "integrity": "sha512-9/MJNpW87XiG9eEzgz/xvNoSmYy1q8VfZD1CZuF+dQYOWmi5qs6QuAo8sjW3V439wtAQeCbrXeQi58lKKyd1mQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1112,9 +1112,9 @@
             }
         },
         "node_modules/@tektronix/script-gen-linux-x64": {
-            "version": "0.1.0-7",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/script-gen-linux-x64/0.1.0-7/ff442cea66869b637c367943ff415e6d20ce16b4",
-            "integrity": "sha512-5AR5t3xHQlxH7ZriRVsW9M5GNFqSc6tDjI+WsQkvycQcwiGy/kng7I3h6wohLSjc7Gse+FLxu+cyvpbWKyBJJg==",
+            "version": "0.1.0-8",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/script-gen-linux-x64/0.1.0-8/12b8dfc65ed46357b6161b13fe4b23b56cdbb884",
+            "integrity": "sha512-CeKIWaTWLMCBziynM/ETb7twsxl7uoM3uZ+s5gYEAjRe/lTAbHXSTYIrsfKfdEiK9uP5CNgHj5wgq5+lM0d3ag==",
             "cpu": [
                 "x64"
             ],
@@ -1128,9 +1128,9 @@
             }
         },
         "node_modules/@tektronix/script-gen-win32-x64": {
-            "version": "0.1.0-7",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/script-gen-win32-x64/0.1.0-7/fa163d5bf77ae2198527d95107dc3238a96ed1d6",
-            "integrity": "sha512-HWeB7WKocTe5kJ9mhaCrqlqbCadBeoLu/mnVygnLVyhzNqdh9JVd7ora0TM+ogEx+9QAt7lsHwuE2DXgCAOqHA==",
+            "version": "0.1.0-8",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/script-gen-win32-x64/0.1.0-8/a3905c88ba83839105112d5896edfdda3c892c9e",
+            "integrity": "sha512-SWgRx5wPvvm+T2ff/sy76nG6v28cU7fsU7nE0qeo0Rxk4xG8mFXyuKGBaDHRCneZbBMaK73xGE/xcIwb2GBIBg==",
             "cpu": [
                 "x64"
             ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Tektronix",
     "displayName": "Tektronix TSP Toolkit",
     "description": "VSCode extension for Tektronix and Keithley instruments that support Test Script Processor (TSP)",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "icon": "./resources/TSP_Toolkit_128x128.png",
     "galleryBanner": {
         "color": "#EEEEEE",
@@ -598,9 +598,9 @@
         "@tektronix/kic-cli-darwin-arm64": "0.21.0",
         "@tektronix/kic-cli-linux-x64": "0.21.0",
         "@tektronix/kic-cli-win32-x64": "0.21.0",
-        "@tektronix/script-gen-win32-x64": "0.1.0-7",
-        "@tektronix/script-gen-darwin-arm64": "0.1.0-7",
-        "@tektronix/script-gen-linux-x64": "0.1.0-7"
+        "@tektronix/script-gen-win32-x64": "0.1.0-8",
+        "@tektronix/script-gen-darwin-arm64": "0.1.0-8",
+        "@tektronix/script-gen-linux-x64": "0.1.0-8"
 
     },
     "extensionDependencies": [


### PR DESCRIPTION
Updated overall version to 1.3.1 and updated tsp-toolkit-script-gen from 0.1.0-7 to 0.1.0-8