### PR TITLE
fix: show all visa connection types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,9 +21,11 @@
     "typescript.tsc.autoDetect": "off",
     "cSpell.words": [
         "categ",
+        "hislip",
         "IIDN",
         "LOGLOC",
-        "rclick"
+        "rclick",
+        "TCPIP"
     ],
     "Lua.workspace.ignoreDir": [],
     "Lua.diagnostics.libraryFiles": "Disable",

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,7 +260,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -1202,7 +1201,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
             "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -1264,7 +1262,6 @@
             "integrity": "sha512-h53RhVyLu6AtpUzVCYLPhZGL5jzTD9fZL+SYf/+hYOx2bDkyQXztXSc4tbvKYHzfMXExMLiL9CWqJmVz6+78IQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.3.0",
                 "@typescript-eslint/types": "8.3.0",
@@ -1685,7 +1682,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2188,7 +2184,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001737",
                 "electron-to-chromium": "^1.5.211",
@@ -3087,9 +3082,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3450,7 +3445,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -3507,7 +3501,6 @@
             "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -3607,7 +3600,6 @@
             "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.7",
                 "array.prototype.findlastindex": "^1.2.3",
@@ -5890,9 +5882,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
         "node_modules/lodash.flattendeep": {
@@ -6561,7 +6553,6 @@
             "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "@istanbuljs/load-nyc-config": "^1.0.0",
                 "@istanbuljs/schema": "^0.1.2",
@@ -7493,7 +7484,6 @@
             "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -9080,9 +9070,9 @@
             }
         },
         "node_modules/ts-node/node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -9298,7 +9288,6 @@
             "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -9341,9 +9330,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "6.21.3",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-            "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+            "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -206,8 +206,8 @@
                 "icon": "$(edit)"
             },
             {
-                "command": "InstrumentsExplorer.updateIPAddr",
-                "title": "Update IP Address",
+                "command": "InstrumentsExplorer.updateInstrumentAddr",
+                "title": "Update Instrument Address",
                 "icon": "$(edit)"
             },
             {
@@ -451,7 +451,7 @@
                     "group": "inline"
                 },
                 {
-                    "command": "InstrumentsExplorer.updateIPAddr",
+                    "command": "InstrumentsExplorer.updateInstrumentAddr",
                     "when": "view == InstrumentsExplorer && viewItem =~ /CONN.*Enabled.*/ && viewItem =~ /CONN.*Active.*/ && !(viewItem =~ /.*Connected.*/)",
                     "group": "inline"
                 },

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -654,13 +654,13 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                         if (this._background_process) {
                             this._background_process?.kill("SIGTERM")
                         }
-                        this.status = ConnectionStatus.Active
+                        this.status = orig_status
                     })
-                    //Dump output queue if enabled
                     if (cancel.isCancellationRequested) {
-                        this.status = ConnectionStatus.Active
+                        this.status = orig_status
                         return false
                     }
+                    //Dump output queue if enabled
                     let dump_path = undefined
                     if (
                         vscode.workspace
@@ -680,7 +680,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                     })
 
                     if (cancel.isCancellationRequested) {
-                        this.status = ConnectionStatus.Active
+                        this.status = orig_status
                         return false
                     }
 
@@ -760,7 +760,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                         message: "Getting instrument information",
                     })
                     if (cancel.isCancellationRequested) {
-                        this.status = ConnectionStatus.Active
+                        this.status = orig_status
                         return false
                     }
 
@@ -770,7 +770,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                         vscode.window.showErrorMessage(
                             `Unable to connect to instrument at ${this.addr}: could not get instrument information`,
                         )
-                        this.status = ConnectionStatus.Active
+                        this.status = orig_status
                         return false
                     }
 
@@ -804,7 +804,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
 
                     //Connect terminal
                     if (cancel.isCancellationRequested) {
-                        this.status = ConnectionStatus.Active
+                        this.status = orig_status
                         return false
                     }
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,5 +1,11 @@
 import * as vscode from "vscode"
-import { idn_to_string, IIDNInfo, InstrInfo } from "./resourceManager"
+import {
+    ConnectionHelper,
+    idn_to_string,
+    IIDNInfo,
+    InstrInfo,
+    IoType,
+} from "./resourceManager"
 import {
     Connection,
     ConnectionStatus,
@@ -204,14 +210,14 @@ export class Instrument extends vscode.TreeItem implements vscode.Disposable {
         }
     }
 
-    sendScript(filepath: string) {
+    async sendScript(filepath: string) {
         const connection = this._connections.find(
             (c) => c.status === ConnectionStatus.Connected,
         )
         if (!connection) {
             return
         }
-        connection.sendScript(filepath)
+        await connection.sendScript(filepath)
     }
     async startSaveTspOutput() {
         this.savingTspOutput = true
@@ -425,7 +431,9 @@ export class Instrument extends vscode.TreeItem implements vscode.Disposable {
     addConnection(connection: Connection): boolean {
         // Find if a connection of the same type already exists (regardless of address)
         const sameTypeIdx = this._connections.findIndex(
-            (v) => v.type === connection.type,
+            (v) =>
+                (v.type === IoType.Lan && v.type === connection.type) ||
+                ConnectionHelper.AreSameVisaType(v.addr, connection.addr),
         )
         if (sameTypeIdx > -1) {
             // If the address is the same, just update status if needed

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -210,14 +210,14 @@ export class Instrument extends vscode.TreeItem implements vscode.Disposable {
         }
     }
 
-    async sendScript(filepath: string) {
+    sendScript(filepath: string) {
         const connection = this._connections.find(
             (c) => c.status === ConnectionStatus.Connected,
         )
         if (!connection) {
             return
         }
-        await connection.sendScript(filepath)
+        connection.sendScript(filepath)
     }
     async startSaveTspOutput() {
         this.savingTspOutput = true

--- a/src/instrumentExplorer.ts
+++ b/src/instrumentExplorer.ts
@@ -168,8 +168,8 @@ export class InstrumentsExplorer implements vscode.Disposable {
 
                 this.intervalID = setInterval(() => {
                     this.treeDataProvider?.getContent().then(
-                        () => { },
-                        () => { },
+                        () => {},
+                        () => {},
                     )
                 }, 1000)
             }
@@ -193,7 +193,7 @@ export class InstrumentsExplorer implements vscode.Disposable {
             })
             item.name = name
             this.treeDataProvider?.doWithConfigWatcherOff(() => {
-                this.treeDataProvider?.updateSaved(item).catch(() => { })
+                this.treeDataProvider?.updateSaved(item).catch(() => {})
             })
         } else {
             Log.warn("Item not defined", {
@@ -210,7 +210,9 @@ export class InstrumentsExplorer implements vscode.Disposable {
         })
 
         if (!newIP || newIP.trim().length === 0) {
-            vscode.window.showErrorMessage("IP address update cancelled or empty")
+            vscode.window.showErrorMessage(
+                "IP address update cancelled or empty",
+            )
             Log.warn("IP address update cancelled or empty", {
                 file: "instruments.ts",
                 func: "InstrumentsExplorer.changeIP()",
@@ -228,9 +230,12 @@ export class InstrumentsExplorer implements vscode.Disposable {
         }
 
         const trimmedIP = newIP.trim()
-        const validationError = ConnectionHelper.instrConnectionStringValidator(trimmedIP)
+        const validationError =
+            ConnectionHelper.instrConnectionStringValidator(trimmedIP)
         if (validationError) {
-            vscode.window.showErrorMessage("Invalid IP address or VISA resource string")
+            vscode.window.showErrorMessage(
+                "Invalid IP address or VISA resource string",
+            )
             Log.warn(`Invalid IP address: ${validationError}`, {
                 file: "instruments.ts",
                 func: "InstrumentsExplorer.changeIP()",
@@ -246,13 +251,18 @@ export class InstrumentsExplorer implements vscode.Disposable {
         item.addr = trimmedIP
         this.treeDataProvider?.addOrUpdateInstrument(item.parent)
         this.treeDataProvider?.doWithConfigWatcherOff(() => {
-            this.treeDataProvider?.updateSaved(item.parent!).catch(() => { })
+            this.treeDataProvider?.updateSaved(item.parent!).catch(() => {})
         })
-        Log.info(`IP address updated from ${oldIP} to ${trimmedIP} for ${item.parent.name}`, {
-            file: "instruments.ts",
-            func: "InstrumentsExplorer.changeIP()",
-        })
-        vscode.window.showInformationMessage(`IP address updated to ${trimmedIP}`)
+        Log.info(
+            `IP address updated from ${oldIP} to ${trimmedIP} for ${item.parent.name}`,
+            {
+                file: "instruments.ts",
+                func: "InstrumentsExplorer.changeIP()",
+            },
+        )
+        vscode.window.showInformationMessage(
+            `IP address updated to ${trimmedIP}`,
+        )
     }
 
     public async saveWhileConnect(instrument: Instrument) {

--- a/src/instrumentExplorer.ts
+++ b/src/instrumentExplorer.ts
@@ -90,9 +90,9 @@ export class InstrumentsExplorer implements vscode.Disposable {
         )
 
         const changeIPAddr = vscode.commands.registerCommand(
-            "InstrumentsExplorer.updateIPAddr",
+            "InstrumentsExplorer.updateInstrumentAddr",
             async (e: Connection) => {
-                await this.updateIPAddr(e)
+                await this.updateInstrumentAddr(e)
             },
         )
 
@@ -203,16 +203,13 @@ export class InstrumentsExplorer implements vscode.Disposable {
         }
     }
 
-    public async updateIPAddr(item: Connection) {
+    public async updateInstrumentAddr(item: Connection) {
         const newIP = await vscode.window.showInputBox({
             placeHolder: "Enter new IP address or VISA resource string",
             prompt: "Enter a valid IPv4 address or VISA resource string",
         })
 
         if (!newIP || newIP.trim().length === 0) {
-            vscode.window.showErrorMessage(
-                "IP address update cancelled or empty",
-            )
             Log.warn("IP address update cancelled or empty", {
                 file: "instruments.ts",
                 func: "InstrumentsExplorer.changeIP()",

--- a/src/instrumentProvider.ts
+++ b/src/instrumentProvider.ts
@@ -162,9 +162,12 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
                 }
                 // Update the address if it changed for this connection
                 const matchingConnection = instrument.connections.find(
-                    (c) => c.type === r.io_type
+                    (c) => c.type === r.io_type,
                 )
-                if (matchingConnection && r.instr_address !== matchingConnection.addr) {
+                if (
+                    matchingConnection &&
+                    r.instr_address !== matchingConnection.addr
+                ) {
                     r.instr_address = matchingConnection.addr
                 }
             }
@@ -545,29 +548,41 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
                         )
                     } else {
                         // Parse discovered instruments
-                        const discoveredInstrInfos = InstrumentProvider.parseDiscoveredInstruments(
-                            jsonRPCResponse,
-                        )
+                        const discoveredInstrInfos =
+                            InstrumentProvider.parseDiscoveredInstruments(
+                                jsonRPCResponse,
+                            )
 
                         // Compare with existing instruments to detect IP address changes
                         for (const discovered of discoveredInstrInfos) {
                             const existing = this._instruments.find(
-                                (i) => i.info.serial_number === discovered.serial_number
+                                (i) =>
+                                    i.info.serial_number ===
+                                    discovered.serial_number,
                             )
-                            
+
                             if (existing) {
-                                const existingAddr = existing.connections[0]?.addr
+                                const existingAddr =
+                                    existing.connections[0]?.addr
                                 const discoveredAddr = discovered.instr_address
-                                
-                                if (existingAddr && existingAddr !== discoveredAddr) {
+
+                                if (
+                                    existingAddr &&
+                                    existingAddr !== discoveredAddr
+                                ) {
                                     // Update the saved instruments configuration if this instrument was saved
                                     if (existing.saved) {
-                                        this.updateSaved(existing).catch((err) => {
-                                            Log.error(`Failed to update saved instrument: ${err}`, {
-                                                file: "instruments.ts",
-                                                func: "InstrumentProvider.getContent()",
-                                            })
-                                        })
+                                        this.updateSaved(existing).catch(
+                                            (err) => {
+                                                Log.error(
+                                                    `Failed to update saved instrument: ${err}`,
+                                                    {
+                                                        file: "instruments.ts",
+                                                        func: "InstrumentProvider.getContent()",
+                                                    },
+                                                )
+                                            },
+                                        )
                                     }
                                 }
                             }
@@ -610,7 +625,8 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
      * to extract the discovered instrument details
      */
     private static parseDiscoveredInstruments(
-        jsonRPCResponse: JSONRPCResponse): InstrInfo[] {
+        jsonRPCResponse: JSONRPCResponse,
+    ): InstrInfo[] {
         const discovery_list: InstrInfo[] = []
         const res: unknown = jsonRPCResponse.result
         if (typeof res === "string") {

--- a/src/resourceManager.ts
+++ b/src/resourceManager.ts
@@ -187,6 +187,29 @@ export class ConnectionHelper {
             val,
         )
     }
+
+    public static AreSameVisaType(a: string, b: string): boolean {
+        const getCaptures = (x: string) => {
+            const { board, protocol, addr, ix, kind } =
+                /^(?<board>(?<protocol>TCPIP|USB|GPIB|ASRL|FIREWIRE|GPIB-VXI|PXI|VXI)\d*)::(?<addr>.+)::(?<ix>.+)::(?<kind>INSTR|SOCKET)/?.exec(
+                    x,
+                )?.groups || {
+                    board: null,
+                    protocol: null,
+                    addr: null,
+                    ix: null,
+                    kind: null,
+                }
+            return { board, protocol, addr, ix, kind }
+        }
+        const a_matches = getCaptures(a)
+        const b_matches = getCaptures(b)
+        return (
+            a_matches.protocol === b_matches.protocol &&
+            a_matches.ix === b_matches.ix &&
+            a_matches.kind === b_matches.kind
+        )
+    }
     public static instrConnectionStringValidator = (val: string) => {
         let conn_str = val
         if (val.split("@").length > 1) {

--- a/src/test/connectionHelper.test.ts
+++ b/src/test/connectionHelper.test.ts
@@ -1,0 +1,38 @@
+import { assert } from "chai"
+import { suite, test } from "mocha"
+import { ConnectionHelper } from "../resourceManager"
+
+suite("ConnectionHelper Test Suite", function () {
+    test("Correctly identify visa strings of the same type", function () {
+        const samples: { a: string; b: string; expected: boolean }[] = [
+            {
+                a: "TCPIP0::domain.something.com::instr0::INSTR",
+                b: "TCPIP0::127.0.0.1::instr0::INSTR",
+                expected: true,
+            },
+            {
+                a: "TCPIP0::domain.something.com::hislip0::INSTR",
+                b: "TCPIP0::127.0.0.1::hislip0::INSTR",
+                expected: true,
+            },
+            {
+                a: "TCPIP0::127.0.0.1::instr0::INSTR",
+                b: "TCPIP0::domain.something.com::hislip0::INSTR",
+                expected: false,
+            },
+            {
+                a: "TCPIP0::127.0.0.1::hislip0::INSTR",
+                b: "TCPIP0::@127.0.0.1::5678::SOCKET",
+                expected: false,
+            },
+            {
+                a: "USB0::0x1234::0x1234::123456::INSTR",
+                b: "TCPIP0::127.0.0.1::hislip0::INSTR",
+                expected: false,
+            },
+        ]
+        samples.forEach((e) => {
+            assert(ConnectionHelper.AreSameVisaType(e.a, e.b) === e.expected)
+        })
+    })
+})


### PR DESCRIPTION
There was an issue where we were only showing one VISA connection address per instrument instead of one VISA connection type per address.

Update dependencies