### PR TITLE
Fix issue in fetching nodes for DMM6500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Added activation dependency check for Linux and Windows
 
+### Fixed
+- (**tsp-toolkit-kic-cli**) Fixed issue in fetching nodes for DMM6500 with no scan card installed
+
 ## [1.4.1]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -679,9 +679,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/kic-cli-darwin-arm64": "0.21.2",
-        "@tektronix/kic-cli-linux-x64": "0.21.2",
-        "@tektronix/kic-cli-win32-x64": "0.21.2",
+        "@tektronix/kic-cli-darwin-arm64": "0.21.3",
+        "@tektronix/kic-cli-linux-x64": "0.21.3",
+        "@tektronix/kic-cli-win32-x64": "0.21.3",
         "@tektronix/script-gen-darwin-arm64": "0.1.1",
         "@tektronix/script-gen-linux-x64": "0.1.1",
         "@tektronix/script-gen-win32-x64": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -679,9 +679,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/kic-cli-darwin-arm64": "0.21.3",
-        "@tektronix/kic-cli-linux-x64": "0.21.3",
-        "@tektronix/kic-cli-win32-x64": "0.21.3",
+        "@tektronix/kic-cli-darwin-arm64": "0.21.3-2",
+        "@tektronix/kic-cli-linux-x64": "0.21.3-2",
+        "@tektronix/kic-cli-win32-x64": "0.21.3-2",
         "@tektronix/script-gen-darwin-arm64": "0.1.1",
         "@tektronix/script-gen-linux-x64": "0.1.1",
         "@tektronix/script-gen-win32-x64": "0.1.1"


### PR DESCRIPTION
Get the resolution to TSP-ToolKit. Update CHANGELOG and kic-cli dependencies to version 0.21.3.