### PR TITLE
Pull in eventlog/errorqueue changes from kic-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - (**tsp-toolkit-kic-cli**) Fixed issue in fetching nodes for DMM6500 with no scan card installed
 - (**tsp-toolkit-kic-cli**) Logout is not happening for MP5000 when connection is disconnected
 - (**tsp-toolkit-webhelp-to-json**) Missing trigger model commands for 2461
+- (**tsp-toolkit-kic-cli**) Correctly decide whether to use `eventlog` or `errorqueue` for `_KIC["error_messages"]()` in common script
 
 ### Changed
 - (**tsp-toolkit-kic-cli**) Removed `kic_` prefix from loaded user scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
                 "vscode": "^1.92.0"
             },
             "optionalDependencies": {
-                "@tektronix/kic-cli-darwin-arm64": "0.21.3-4",
-                "@tektronix/kic-cli-linux-x64": "0.21.3-4",
-                "@tektronix/kic-cli-win32-x64": "0.21.3-4",
+                "@tektronix/kic-cli-darwin-arm64": "0.21.3-5",
+                "@tektronix/kic-cli-linux-x64": "0.21.3-5",
+                "@tektronix/kic-cli-win32-x64": "0.21.3-5",
                 "@tektronix/script-gen-darwin-arm64": "0.1.2-0",
                 "@tektronix/script-gen-linux-x64": "0.1.2-0",
                 "@tektronix/script-gen-win32-x64": "0.1.2-0",
@@ -263,7 +263,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -1017,9 +1016,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-darwin-arm64": {
-            "version": "0.21.3-4",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-darwin-arm64/0.21.3-4/78d13032a5d172ea234c12634fb359fd4824f9a3",
-            "integrity": "sha512-FskW9DyqlDKrKFtJS2q+mRyy/jd8m4fCJWKOWH+RdonwdUpQq/Wsm31Qvq3ZJ3ChoDtoeYuNuZhIDITrDlUXPA==",
+            "version": "0.21.3-5",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-darwin-arm64/0.21.3-5/9f0965d4f81cca7eadf09544bbd4ba08876ccc8b",
+            "integrity": "sha512-pL7WUud/s9Y6ipN3i98tdE40+e7VnmTymSLTCvg3aoeYOwG40isbqSOW4358Qg60RvnEmvRMyvr/LNK+poHImA==",
             "cpu": [
                 "arm64"
             ],
@@ -1037,9 +1036,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-linux-x64": {
-            "version": "0.21.3-4",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-linux-x64/0.21.3-4/f454349437046644fa31673e599d2347bb84a168",
-            "integrity": "sha512-1QbS5Avi5v90Xq6Hhdjh0DS4oEcfah+vAmM82cshWrse3E1MHd6BOHAwMxbt4ZnzjyXWIjHQziso/Bm0BzfzVA==",
+            "version": "0.21.3-5",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-linux-x64/0.21.3-5/1ac45d44ac7c3e656a476bc11ba151d2b8d954ec",
+            "integrity": "sha512-QqJQkl/81CcX+3x7duP2Rat5GV3S4XTjK7tF4FsSbtVf5+29jaTYF9vgcUL2nBIzsP5VLOVg/FJsqBSK9WC/0w==",
             "cpu": [
                 "x64"
             ],
@@ -1057,9 +1056,9 @@
             }
         },
         "node_modules/@tektronix/kic-cli-win32-x64": {
-            "version": "0.21.3-4",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-win32-x64/0.21.3-4/916df3f46042e13874c05b404ca049516e3c43a6",
-            "integrity": "sha512-DWK44o+YepHsLJIYttdD1fUkktkp7aDsLCKDDB85wd9wyk31+47vBOUVpUvdkeWmgZizStlx0w6XXE/q0VCJhw==",
+            "version": "0.21.3-5",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/kic-cli-win32-x64/0.21.3-5/f60d09cbc35bff871beb857295274013decc03dc",
+            "integrity": "sha512-d6O2h/pPTzUEBVPhSyiix6ZrPZjZBW0U8QAl/38q58euqlS5LLecOGt+7tlREDDhQJGlHhcm6YS7hSJSSXaf4Q==",
             "cpu": [
                 "x64"
             ],
@@ -1241,7 +1240,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
             "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -1303,7 +1301,6 @@
             "integrity": "sha512-h53RhVyLu6AtpUzVCYLPhZGL5jzTD9fZL+SYf/+hYOx2bDkyQXztXSc4tbvKYHzfMXExMLiL9CWqJmVz6+78IQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.3.0",
                 "@typescript-eslint/types": "8.3.0",
@@ -1724,7 +1721,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2180,7 +2176,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001737",
                 "electron-to-chromium": "^1.5.211",
@@ -3420,7 +3415,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -3477,7 +3471,6 @@
             "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -3577,7 +3570,6 @@
             "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.7",
                 "array.prototype.findlastindex": "^1.2.3",
@@ -6688,7 +6680,6 @@
             "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "@istanbuljs/load-nyc-config": "^1.0.0",
                 "@istanbuljs/schema": "^0.1.2",
@@ -7620,7 +7611,6 @@
             "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -9426,7 +9416,6 @@
             "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -748,9 +748,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/kic-cli-darwin-arm64": "0.21.3-4",
-        "@tektronix/kic-cli-linux-x64": "0.21.3-4",
-        "@tektronix/kic-cli-win32-x64": "0.21.3-4",
+        "@tektronix/kic-cli-darwin-arm64": "0.21.3-5",
+        "@tektronix/kic-cli-linux-x64": "0.21.3-5",
+        "@tektronix/kic-cli-win32-x64": "0.21.3-5",
         "@tektronix/script-gen-darwin-arm64": "0.1.2-0",
         "@tektronix/script-gen-linux-x64": "0.1.2-0",
         "@tektronix/script-gen-win32-x64": "0.1.2-0",


### PR DESCRIPTION
Pull in corrections in https://github.com/tektronix/tsp-toolkit-kic-cli that the terminal hanging because of `_KIC.error_message()` not using the correct thing between `errorqueue` and `eventlog`.