### PR TITLE
Rename "Script Generation" view to "Tools"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 - (**tsp-toolkit-kic-cli**) Removed `kic_` prefix from loaded user scripts
+- Rename "Script Generation" view to "Tools"
 
 ## [1.4.1]
 

--- a/package.json
+++ b/package.json
@@ -630,8 +630,9 @@
                     "type": "webview"
                 },
                 {
-                    "id": "ScriptGenView",
-                    "name": "Script Generation"
+                    "id": "ToolsView",
+                    "name": "Tools",
+                    "icon": "resources/dark/script-gen-pane-icon.svg"
                 }
             ]
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -429,7 +429,7 @@ export function activate(context: vscode.ExtensionContext) {
         triggerFlowDataProvider,
     )
 
-    const treeView = vscode.window.createTreeView("ScriptGenView", {
+    const treeView = vscode.window.createTreeView("ToolsView", {
         treeDataProvider: combinedProvider,
     })
 

--- a/src/genericSessionDataProvider.ts
+++ b/src/genericSessionDataProvider.ts
@@ -72,6 +72,16 @@ implements vscode.TreeDataProvider<TreeItemType>
     private sessionTypeNode: SessionTypeTreeItem
     public activeSessionName: string | undefined
 
+    /**
+     * Constructor for GenericSessionDataProvider
+     *
+     * @param storage - Instance of GenericSessionStorage for managing session data
+     * @param sessionTypeLabel - Label for the session type that will be displayed in the tree view (e.g., "I-V Characterization")
+     * @param treeItemContextValue - Context value for session type tree item
+     * @param instanceContextValue - Context value for session instance tree items
+     * @param activeInstanceContextValue - Context value for active session instance tree items
+     * @param commandId - Command ID to execute when a session instance is clicked
+     */
     constructor(
         private readonly storage: GenericSessionStorage,
         private readonly sessionTypeLabel: string,

--- a/src/scriptGenDataProvider.ts
+++ b/src/scriptGenDataProvider.ts
@@ -9,7 +9,7 @@ export class ScriptGenDataProvider extends GenericSessionDataProvider {
     constructor(storage: GenericSessionStorage) {
         super(
             storage,
-            "I-V Characterization",
+            "I-V Characterization Script Generation", // This will be the name shown in the tree view
             "SavedIVCharTreeItem",
             "SavedIVCharInstance",
             "ActiveSavedIVCharInstance",

--- a/src/triggerFlowWebViewManager.ts
+++ b/src/triggerFlowWebViewManager.ts
@@ -31,21 +31,21 @@ export class TriggerFlowWebViewManager extends BaseSessionManager<
         const config: SessionConfig = {
             executablePath: SCRIPT_GEN_EXECUTABLE,
             serverPort: 27950, // Different port from script gen
-            panelTitle: "Trigger Flow Canvas",
+            panelTitle: "Trigger Flow",
             iconPaths: {
                 light: path.join(
                     __dirname,
                     "..",
                     "resources",
                     "light",
-                    "trigger-flow-pane-icon.svg",
+                    "script-gen-pane-icon.svg",
                 ),
                 dark: path.join(
                     __dirname,
                     "..",
                     "resources",
                     "dark",
-                    "trigger-flow-pane-icon.svg",
+                    "script-gen-pane-icon.svg",
                 ),
             },
             viewCommandId: "tsp.viewTriggerFlowUI",


### PR DESCRIPTION
This is to support putting other specialized tools in this view for users to interact with. It is more generic wording and thus allows for more possibilities.

Resolves: TSP-1554