### PR TITLE
Support `tspa` Files, Lua 5.0 disclaimer, Dep Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Enable send script command in command palette
 - Added command to delete all scriptgen sessions
 - Added TSP Toolkit Quick Start Guide link to Learning Resources section in README.md
+- Support TSP files with the `.tspa` extension
 - (**tsp-toolkit-webhelp**) Added webhelp manuals for DMM7510
 - (**tsp-toolkit-webhelp-to-json**) Added language feature support for DMM7512, DMM6500 and DAQ6510
 - (**tsp-toolkit-kic-cli**) Add `--save` and `--run <RUN_ENABLE>` args for `.script` command to allow users to save scripts to non-volatile instrument memory

--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ for more information.
 - When upgrading an MP5103 mainframe over USBTMC or HiSLIP, IO errors may occur. Prefer using raw sockets (just the IP address) to flash firmware.
 - When upgrading TTI and 2600 products over VXI-11, IO Errors may occur. Prefer using raw sockets (just the IP address) to flash firmware.
 - There are occasional issues running scripts over VXI-11 on 2600 products that lead to mysterious TSP errors.
+- Due to limitations within the LuaLS project, we are unable to fully support Lua 5.0 and
+  instead use Lua 5.1. Certain language feature in Lua 5.1 incorrectly appear to be supported in TSP
+  such as using `#lua_table` to get the number of elements in a table.
 
 <!--Refs-->
 [official-Lua-5.0-reference]: https://www.lua.org/manual/5.0/

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
                 "when": "true",
                 "icon": "./resources/TSP_Toolkit_128x128.png",
                 "featuredFor": [
-                    "**/*.tsp"
+                    "**/*.tsp",
+                    "**/*.tspa"
                 ],
                 "steps": [
                     {
@@ -426,21 +427,21 @@
         "menus": {
             "editor/context": [
                 {
-                    "when": "activeEditor && resourceExtname == .tsp",
+                    "when": "activeEditor && ( resourceExtname == .tsp || resourceExtname == .tspa )",
                     "command": "tsp.sendFile",
                     "group": "navigation"
                 }
             ],
             "explorer/context": [
                 {
-                    "when": "activeEditor && resourceExtname == .tsp",
+                    "when": "activeEditor && ( resourceExtname == .tsp || resourceExtname == .tspa )",
                     "command": "tsp.sendFile",
                     "group": "navigation"
                 }
             ],
             "editor/title/context": [
                 {
-                    "when": "activeEditor && resourceExtname == .tsp",
+                    "when": "activeEditor && ( resourceExtname == .tsp || resourceExtname == .tspa )",
                     "command": "tsp.sendFile",
                     "group": "navigation"
                 }
@@ -594,17 +595,17 @@
             "editor/title/run": [
                 {
                     "command": "tsp.sendFile",
-                    "when": "resourceExtname == .tsp",
+                    "when": "resourceExtname == .tsp || resourceExtname == .tspa",
                     "group": "navigation@1"
                 },
                 {
                     "command": "tspdebug.debugContent",
-                    "when": "resourceExtname == .tsp",
+                    "when": "resourceExtname == .tsp || resourceExtname == .tspa",
                     "group": "navigation@2"
                 },
                 {
                     "command": "tsp.saveScriptOutput",
-                    "when": "resourceExtname == .tsp",
+                    "when": "resourceExtname == .tsp || resourceExtname == .tspa",
                     "group": "navigation@3"
                 }
             ]

--- a/src/dependencyChecker.ts
+++ b/src/dependencyChecker.ts
@@ -431,6 +431,7 @@ interface MissingDependency {
     description: string
     downloadUrl: string
     learnMoreUrl?: string
+    optional?: boolean
 }
 
 /**
@@ -583,19 +584,23 @@ async function showMissingDependenciesNotification(
     while (true) {
         // Build the message
         let message = ""
+        let depList = ""
 
-        if (missing.length === 1) {
-            message = `${missing[0].name} is required but not detected on your system.`
-        } else {
-            // Create a numbered list
-            const depList = missing
-                .map((dep, index) => `${index + 1}. ${dep.name}`) // 1. Name, 2. Name, ...
-                .join("\n")
-            message = `${missing.length} required dependencies are missing: [ ${depList} ].`
+        const numRequired = missing.filter((dep) => !dep.optional).length
+        const numOptional = missing.filter((dep) => dep.optional).length
+        const hasRequired = numRequired > 0
+
+        // Create a numbered list
+        depList = missing
+            .map((dep, index) => `${index + 1}. ${dep.name}`) // 1. Name, 2. Name, ...
+            .join("\n")
+        message = `TSP Toolkit: ${numRequired > 0 ? `${numRequired} required ${numOptional > 0 ? "and " : ""}` : ""}${numOptional > 0 ? `${numOptional} optional ` : ""}${missing.length === 1 ? "dependency is" : "dependencies are"} missing. Some features may not work correctly without required dependencies`
+
+        if (!hasRequired) {
+            message += "\n" + depList + "\n"
         }
 
-        const exclamation = "\u2757"
-        message += `\u00A0\u00A0${exclamation} Some features may not work correctly without these dependencies.`
+        console.log(message)
 
         // Create action buttons based on number of dependencies
         const actions: string[] = []
@@ -617,8 +622,13 @@ async function showMissingDependenciesNotification(
 
         actions.push("Dismiss")
 
-        const selection = await vscode.window.showWarningMessage(
+        const messageApi = hasRequired
+            ? vscode.window.showErrorMessage
+            : vscode.window.showWarningMessage
+
+        const selection = await messageApi(
             message,
+            { modal: hasRequired, detail: depList },
             ...actions,
         )
 
@@ -689,6 +699,7 @@ export async function checkSystemDependencies(): Promise<void> {
                     "https://www.ni.com/en-us/support/downloads/drivers/download.ni-visa.html",
                 learnMoreUrl:
                     "https://www.ivifoundation.org/specifications/default.aspx",
+                optional: true,
             })
         } else {
             Log.debug("VISA installation detected", logloc)
@@ -739,6 +750,7 @@ export async function checkSystemDependencies(): Promise<void> {
                     "https://www.ni.com/en-us/support/downloads/drivers/download.ni-visa.html",
                 learnMoreUrl:
                     "https://www.ivifoundation.org/specifications/default.aspx",
+                optional: true,
             })
         } else {
             Log.debug("VISA installation detected on Linux", logloc)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -306,7 +306,8 @@ export function activate(context: vscode.ExtensionContext) {
                     const activeEditor = vscode.window.activeTextEditor
                     if (
                         activeEditor &&
-                        activeEditor.document.uri.fsPath.endsWith(".tsp")
+                        (activeEditor.document.uri.fsPath.endsWith(".tsp") ||
+                            activeEditor.document.uri.fsPath.endsWith(".tspa"))
                     ) {
                         e = activeEditor.document.uri
                     } else {

--- a/src/workspaceManager.ts
+++ b/src/workspaceManager.ts
@@ -41,6 +41,7 @@ export async function configure_initial_workspace_configurations() {
         "files.associations",
         {
             "*.tsp": "lua",
+            "*.tspa": "lua",
         },
         vscode.ConfigurationTarget.Global,
     )


### PR DESCRIPTION
- Support files with the `.tspa` extension
- Add a disclaimer to the README for Lua 5.1/5.2 discrepancies
- Improve reporting of dependency issues