### PR TITLE
Update GitHub Actions, Enable Veracode

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Tool Versions
         run: npx prettier --version
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: run prettier
         run: npx prettier --list-different
 
@@ -42,7 +42,7 @@ jobs:
       - name: Tool Versions
         run: npx eslint --version
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
@@ -63,7 +63,7 @@ jobs:
         password: ${{secrets.GITHUB_TOKEN}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Tools
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
@@ -71,7 +71,7 @@ jobs:
       - name: Generate NPM BOM
         run: npx @cyclonedx/cyclonedx-npm --output-format JSON --package-lock-only --output-reproducible --output-file npm.cdx.json
       - name: Upload Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: software-bom
           path: |
@@ -90,7 +90,7 @@ jobs:
       - name: Tool Versions
         run: npx prettier --version
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
@@ -126,7 +126,7 @@ jobs:
         run: |
           npm --version
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
@@ -137,7 +137,7 @@ jobs:
         run: |
           npx vsce package --target ${{matrix.vscode-platform}}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-${{matrix.vscode-platform}}
           path: "*.vsix"
@@ -172,7 +172,7 @@ jobs:
         password: ${{secrets.GITHUB_TOKEN}}
     steps:
       - name: Get Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package-${{matrix.vscode-platform}}
           path: extension
@@ -201,12 +201,12 @@ jobs:
     if: ${{ (endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/')) && github.event.pull_request.merged ) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Get Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: package-*
           merge-multiple: true
@@ -238,7 +238,7 @@ jobs:
     if: ${{ (endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/')) || github.event.pull_request.merged ) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -280,13 +280,13 @@ jobs:
 
       - run: 'git tag --list ${V}*'
       - name: Get Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: package-*
           merge-multiple: true
           path: extension
       #- name: Get SBOM
-      #  uses: actions/download-artifact@v4
+      #  uses: actions/download-artifact@v8
       #  with:
       #    name: software-bom
       #    path: sbom

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           appname: "tsp-toolkit"
           createprofile: false
-          version: ${{ case( (endsWith(github.ref, 'main') && contains(github.head_ref, 'release/') && github.event.pull_request.merged ), 'release', (startsWith(github.ref, 'refs/release/') && startsWith(github.head_ref, 'refs/pull/')), 'pr-${{ github.ref_name}}', 'other') }}-${{ github.sha }}-${{github.job}}-${{github.run_id}}-${{github.run_attempt}}
+          version: ${{ case( (endsWith(github.ref, 'main') && contains(github.head_ref, 'release/') && github.event.pull_request.merged ), 'release', 'pr-${{ github.ref_name}}') }}-${{ github.sha }}-${{github.job}}-${{github.run_id}}-${{github.run_attempt}}
           filepath: "app.zip"
           scantimeout: 30
           vid: ${{ secrets.VERACODE_API_ID }}

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           appname: "tsp-toolkit"
           createprofile: false
-          version: ${{ case( (endsWith(github.ref, 'main') && contains(github.head_ref, 'release/') && github.event.pull_request.merged ), 'release', 'pr-${{ github.ref_name}}') }}-${{ github.sha }}-${{github.job}}-${{github.run_id}}-${{github.run_attempt}}
+          version: ${{ case( (endsWith(github.ref, 'main') && contains(github.head_ref, 'release/') && github.event.pull_request.merged ), 'release', github.ref_name) }}-${{ github.sha }}-${{github.job}}-${{github.run_id}}-${{github.run_attempt}}
           filepath: "app.zip"
           scantimeout: 30
           vid: ${{ secrets.VERACODE_API_ID }}

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+      - release/*
+    tags:
+      - "*"
+  pull_request:
+     types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
   workflow_dispatch:
 
 jobs:
@@ -25,7 +34,7 @@ jobs:
         with:
           appname: "tsp-toolkit"
           createprofile: false
-          version: ${{ github.sha }}
+          version: ${{ case( (endsWith(github.ref, 'main') && contains(github.head_ref, 'release/') && github.event.pull_request.merged ), 'release', (startsWith(github.ref, 'refs/release/') && startsWith(github.head_ref, 'refs/pull/')), 'pr-${{ github.ref_name}}', 'other') }}-${{ github.sha }}-${{github.job}}-${{github.run_id}}-${{github.run_attempt}}
           filepath: "app.zip"
           scantimeout: 30
           vid: ${{ secrets.VERACODE_API_ID }}

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: create new package-lock.json
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
@@ -21,7 +21,7 @@ jobs:
       - name: ZIP source folder
         run: zip -r app.zip src package-lock.json
       - name: Run Veracode Policy scan
-        uses: veracode/veracode-uploadandscan-action@0.2.6
+        uses: veracode/veracode-uploadandscan-action@0.2.10
         with:
           appname: "tsp-toolkit"
           createprofile: false


### PR DESCRIPTION
- Update GitHub Actions to fix "node 20" deprecation alerts
- Update Veracode action
- Change name of Veracode scan to be unique between runs