### PR TITLE
Added command palette command to reset tsp toolkit to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - **tsp-toolkit-trigger-flow** - Multiple issues have been corrected for delay time and number of delays parameter.
 
 ### Added
+- Added Reset to Default command in command palette.
 - **tsp-toolkit-trigger-flow** - Maximum limit of 10k for number of delay parameter.
 - **tsp-toolkit-trigger-flow** - Display maximum models allowed based on system configuration.
 - **tsp-toolkit-trigger-flow** - Display trigger model name and slot information for selected block.

--- a/package.json
+++ b/package.json
@@ -331,8 +331,8 @@
                 "icon": "$(trash)"
             },
             {
-                "command": "tsp.resetToolkitDefaults",
-                "title": "Reset TSP Toolkit to Defaults",
+                "command": "tsp.resetToDefaults",
+                "title": "Reset to Defaults",
                 "category": "TSP",
                 "icon": "$(trash)"
             }

--- a/package.json
+++ b/package.json
@@ -329,6 +329,12 @@
                 "title": "Delete all TriggerFlow sessions",
                 "category": "TSP",
                 "icon": "$(trash)"
+            },
+            {
+                "command": "tsp.resetToolkitDefaults",
+                "title": "Reset TSP Toolkit to Defaults",
+                "category": "TSP",
+                "icon": "$(trash)"
             }
         ],
         "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,68 @@ import {
 let _instrExplorer: InstrumentsExplorer
 
 /**
+ * Represents a contributed TSP Toolkit configuration setting.
+ */
+interface ResettableSetting {
+    key: string
+    label: string
+    description?: string
+}
+
+/**
+ * Represents one reset option shown to the user.
+ */
+interface ResetAction {
+    id: string
+    label: string
+    description: string
+    detail?: string
+    execute(): Promise<void>
+}
+
+interface ManifestConfigurationSection {
+    properties?: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null
+}
+
+function getManifestConfigurationSections(
+    packageJson: unknown,
+): ManifestConfigurationSection[] {
+    if (!isRecord(packageJson)) {
+        return []
+    }
+
+    const contributes = packageJson["contributes"]
+    if (!isRecord(contributes)) {
+        return []
+    }
+
+    const configuration = contributes["configuration"]
+    if (Array.isArray(configuration)) {
+        return configuration.filter(isRecord)
+    }
+
+    if (isRecord(configuration)) {
+        return [configuration]
+    }
+
+    return []
+}
+
+const RESET_LABELS: Record<string, string> = {
+    "tsp.savedInstruments": "Saved Instruments",
+    "tsp.tspLinkSystemConfigurations": "Saved Instrument Configurations",
+    "tsp.lineFrequency": "Power Line Frequency",
+    "tsp.ignoreMissingVisa": "Ignore Missing VISA Warning",
+    "tsp.showFunction": "Show Functions in Variables Pane",
+    "tsp.reset": "Reset Instrument on Connection",
+    "tsp.clearErrorQueue": "Clear Error Queue on Connection",
+}
+
+/**
  * Function will create terminal with given connection details
  * @param connection_string connection string example 'tsPop@127.0.0.1'
  * @param model_serial model serial number
@@ -441,6 +503,12 @@ export function activate(context: vscode.ExtensionContext) {
                 }
             },
         },
+        {
+            name: "tsp.resetToolkitDefaults",
+            cb: async () => {
+                await resetToolkitDefaults()
+            },
+        },
     ])
 
     Log.debug("Setting up HelpDocumentWebView", LOGLOC)
@@ -593,6 +661,203 @@ function updateExtensionSettings() {
                 })
         }
     })
+}
+
+function collectResettableSettings(): ResettableSetting[] {
+    const extension = vscode.extensions.getExtension("Tektronix.tsp-toolkit")
+
+    const configs = getManifestConfigurationSections(extension?.packageJSON)
+
+    if (configs.length === 0) {
+        return []
+    }
+
+    const settings: ResettableSetting[] = []
+
+    for (const config of configs) {
+        const properties = config.properties ?? {}
+
+        for (const [key, value] of Object.entries(properties)) {
+            if (!key.startsWith("tsp.")) {
+                continue
+            }
+
+            const property = value as {
+                description?: string
+                markdownDescription?: string
+            }
+
+            settings.push({
+                key,
+                label: RESET_LABELS[key] ?? key,
+                description:
+                    property.description ?? property.markdownDescription,
+            })
+        }
+    }
+
+    return settings
+}
+
+async function resetConfigurationKey(key: string): Promise<boolean> {
+    const configuration = vscode.workspace.getConfiguration()
+
+    const inspect = configuration.inspect(key)
+
+    if (!inspect) {
+        return false
+    }
+
+    let updated = false
+
+    if (inspect.globalValue !== undefined) {
+        await configuration.update(
+            key,
+            undefined,
+            vscode.ConfigurationTarget.Global,
+        )
+        updated = true
+    }
+
+    if (inspect.workspaceValue !== undefined) {
+        await configuration.update(
+            key,
+            undefined,
+            vscode.ConfigurationTarget.Workspace,
+        )
+        updated = true
+    }
+
+    if (inspect.workspaceFolderValue !== undefined) {
+        await configuration.update(
+            key,
+            undefined,
+            vscode.ConfigurationTarget.WorkspaceFolder,
+        )
+        updated = true
+    }
+
+    return updated
+}
+
+//Reset multiple settings and return the number of settings that were reset
+async function resetSettings(settings: ResettableSetting[]): Promise<number> {
+    let count = 0
+
+    for (const setting of settings) {
+        if (await resetConfigurationKey(setting.key)) {
+            count++
+        }
+    }
+
+    return count
+}
+
+//Build a list of reset actions for the user to choose from
+function buildResetActions(): ResetAction[] {
+    const settings = collectResettableSettings()
+
+    const savedInstruments = settings.filter(
+        (s) => s.key === "tsp.savedInstruments",
+    )
+
+    const systemConfigurations = settings.filter(
+        (s) => s.key === "tsp.tspLinkSystemConfigurations",
+    )
+
+    const otherSettings = settings.filter(
+        (s) =>
+            s.key !== "tsp.savedInstruments" &&
+            s.key !== "tsp.tspLinkSystemConfigurations",
+    )
+
+    return [
+        {
+            id: "savedInstruments",
+            label: "Saved Instruments",
+            description: "Reset saved instruments",
+            execute: async () => {
+                await resetSettings(savedInstruments)
+            },
+        },
+
+        {
+            id: "systemConfigurations",
+            label: "Saved Instrument Configurations",
+            description: "Reset saved instrument configurations",
+            execute: async () => {
+                await resetSettings(systemConfigurations)
+            },
+        },
+
+        {
+            id: "preferences",
+            label: "Other TSP Toolkit Preferences",
+            description: "Reset remaining extension settings",
+            detail: otherSettings.map((s) => s.label).join(", "),
+            execute: async () => {
+                await resetSettings(otherSettings)
+            },
+        },
+
+        {
+            id: "scriptGen",
+            label: "Delete Script Generation Sessions",
+            description: "Delete all Script Generation sessions",
+            execute: async () => {
+                await vscode.commands.executeCommand(
+                    "tsp.deleteAllScriptGenSessions",
+                )
+            },
+        },
+
+        {
+            id: "triggerFlow",
+            label: "Delete TriggerFlow Sessions",
+            description: "Delete all TriggerFlow sessions",
+            execute: async () => {
+                await vscode.commands.executeCommand(
+                    "tsp.deleteAllTriggerFlowSessions",
+                )
+            },
+        },
+    ]
+}
+
+async function resetToolkitDefaults() {
+    const actions = buildResetActions()
+
+    const picks = actions.map((action) => ({
+        label: action.label,
+        description: action.description,
+        detail: action.detail,
+        action,
+    }))
+
+    const selected = await vscode.window.showQuickPick(picks, {
+        title: "Reset TSP Toolkit",
+        canPickMany: true,
+    })
+
+    if (!selected?.length) {
+        return
+    }
+
+    const confirmation = await vscode.window.showWarningMessage(
+        `Reset ${selected.length} selected item(s)?`,
+        { modal: true },
+        "Reset",
+    )
+
+    if (confirmation !== "Reset") {
+        return
+    }
+
+    for (const item of selected) {
+        await item.action.execute()
+    }
+
+    vscode.window.showInformationMessage("TSP Toolkit reset completed.")
 }
 
 export async function pickConnection(): Promise<Connection | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -740,7 +740,7 @@ async function resetConfigurationKey(key: string): Promise<boolean> {
     return updated
 }
 
-//Reset multiple settings and return the number of settings that were reset
+//Reset multiple settings and return the number of setting keys that were reset
 async function resetSettings(settings: ResettableSetting[]): Promise<number> {
     let count = 0
 
@@ -846,8 +846,10 @@ async function resetToolkitDefaults() {
         return
     }
 
+    const selectedSummary = selected.map((item) => `- ${item.label}`).join("\n")
+
     const confirmation = await vscode.window.showWarningMessage(
-        `Reset ${selected.length} selected item(s)?`,
+        `You are about to reset the following item(s):\n${selectedSummary}\n\nThis action cannot be undone. Continue?`,
         { modal: true },
         "Reset",
     )
@@ -863,7 +865,7 @@ async function resetToolkitDefaults() {
     }
 
     vscode.window.showInformationMessage(
-        `TSP Toolkit reset completed. ${processedCount} reset operation(s) were applied across ${selected.length} selected item(s).`,
+        `TSP Toolkit reset completed. Processed ${selected.length} selected reset item(s) and applied ${processedCount} change(s).`,
     )
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ interface ResetAction {
     label: string
     description: string
     detail?: string
-    execute(): Promise<void>
+    execute(): Promise<number>
 }
 
 interface ManifestConfigurationSection {
@@ -768,7 +768,8 @@ function buildResetActions(): ResetAction[] {
     const otherSettings = settings.filter(
         (s) =>
             s.key !== "tsp.savedInstruments" &&
-            s.key !== "tsp.tspLinkSystemConfigurations",
+            s.key !== "tsp.tspLinkSystemConfigurations" &&
+            s.key !== "tsp.script_generation",
     )
 
     return [
@@ -776,8 +777,8 @@ function buildResetActions(): ResetAction[] {
             id: "savedInstruments",
             label: "Saved Instruments",
             description: "Reset saved instruments",
-            execute: async () => {
-                await resetSettings(savedInstruments)
+            execute: async (): Promise<number> => {
+                return resetSettings(savedInstruments)
             },
         },
 
@@ -785,8 +786,8 @@ function buildResetActions(): ResetAction[] {
             id: "systemConfigurations",
             label: "Saved Instrument Configurations",
             description: "Reset saved instrument configurations",
-            execute: async () => {
-                await resetSettings(systemConfigurations)
+            execute: async (): Promise<number> => {
+                return resetSettings(systemConfigurations)
             },
         },
 
@@ -795,8 +796,8 @@ function buildResetActions(): ResetAction[] {
             label: "Other TSP Toolkit Preferences",
             description: "Reset remaining extension settings",
             detail: otherSettings.map((s) => s.label).join(", "),
-            execute: async () => {
-                await resetSettings(otherSettings)
+            execute: async (): Promise<number> => {
+                return resetSettings(otherSettings)
             },
         },
 
@@ -804,10 +805,11 @@ function buildResetActions(): ResetAction[] {
             id: "scriptGen",
             label: "Delete Script Generation Sessions",
             description: "Delete all Script Generation sessions",
-            execute: async () => {
+            execute: async (): Promise<number> => {
                 await vscode.commands.executeCommand(
                     "tsp.deleteAllScriptGenSessions",
                 )
+                return 1
             },
         },
 
@@ -815,10 +817,11 @@ function buildResetActions(): ResetAction[] {
             id: "triggerFlow",
             label: "Delete TriggerFlow Sessions",
             description: "Delete all TriggerFlow sessions",
-            execute: async () => {
+            execute: async (): Promise<number> => {
                 await vscode.commands.executeCommand(
                     "tsp.deleteAllTriggerFlowSessions",
                 )
+                return 1
             },
         },
     ]
@@ -853,11 +856,15 @@ async function resetToolkitDefaults() {
         return
     }
 
+    let processedCount = 0
+
     for (const item of selected) {
-        await item.action.execute()
+        processedCount += await item.action.execute()
     }
 
-    vscode.window.showInformationMessage("TSP Toolkit reset completed.")
+    vscode.window.showInformationMessage(
+        `TSP Toolkit reset completed. ${processedCount} reset operation(s) were applied across ${selected.length} selected item(s).`,
+    )
 }
 
 export async function pickConnection(): Promise<Connection | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ interface ResetAction {
     label: string
     description: string
     detail?: string
-    execute(): Promise<number>
+    execute(): Promise<void>
 }
 
 interface ManifestConfigurationSection {
@@ -740,17 +740,11 @@ async function resetConfigurationKey(key: string): Promise<boolean> {
     return updated
 }
 
-//Reset multiple settings and return the number of setting keys that were reset
-async function resetSettings(settings: ResettableSetting[]): Promise<number> {
-    let count = 0
-
+//Reset multiple settings to their default values
+async function resetSettings(settings: ResettableSetting[]): Promise<void> {
     for (const setting of settings) {
-        if (await resetConfigurationKey(setting.key)) {
-            count++
-        }
+        await resetConfigurationKey(setting.key)
     }
-
-    return count
 }
 
 //Build a list of reset actions for the user to choose from
@@ -777,8 +771,8 @@ function buildResetActions(): ResetAction[] {
             id: "savedInstruments",
             label: "Saved Instruments",
             description: "Reset saved instruments",
-            execute: async (): Promise<number> => {
-                return resetSettings(savedInstruments)
+            execute: async (): Promise<void> => {
+                await resetSettings(savedInstruments)
             },
         },
 
@@ -786,8 +780,8 @@ function buildResetActions(): ResetAction[] {
             id: "systemConfigurations",
             label: "Saved Instrument Configurations",
             description: "Reset saved instrument configurations",
-            execute: async (): Promise<number> => {
-                return resetSettings(systemConfigurations)
+            execute: async (): Promise<void> => {
+                await resetSettings(systemConfigurations)
             },
         },
 
@@ -796,8 +790,8 @@ function buildResetActions(): ResetAction[] {
             label: "Other TSP Toolkit Preferences",
             description: "Reset remaining extension settings",
             detail: otherSettings.map((s) => s.label).join(", "),
-            execute: async (): Promise<number> => {
-                return resetSettings(otherSettings)
+            execute: async (): Promise<void> => {
+                await resetSettings(otherSettings)
             },
         },
 
@@ -805,11 +799,10 @@ function buildResetActions(): ResetAction[] {
             id: "scriptGen",
             label: "Delete Script Generation Sessions",
             description: "Delete all Script Generation sessions",
-            execute: async (): Promise<number> => {
+            execute: async (): Promise<void> => {
                 await vscode.commands.executeCommand(
                     "tsp.deleteAllScriptGenSessions",
                 )
-                return 1
             },
         },
 
@@ -817,11 +810,10 @@ function buildResetActions(): ResetAction[] {
             id: "triggerFlow",
             label: "Delete TriggerFlow Sessions",
             description: "Delete all TriggerFlow sessions",
-            execute: async (): Promise<number> => {
+            execute: async (): Promise<void> => {
                 await vscode.commands.executeCommand(
                     "tsp.deleteAllTriggerFlowSessions",
                 )
-                return 1
             },
         },
     ]
@@ -846,27 +838,24 @@ async function resetToolkitDefaults() {
         return
     }
 
-    const selectedSummary = selected.map((item) => `- ${item.label}`).join("\n")
+    //const selectedSummary = selected.map((item) => item.label).join(", ")
+    const selectedSummary = selected.map((item, index) => `${index + 1}. ${item.label}`).join(", ")
 
     const confirmation = await vscode.window.showWarningMessage(
-        `You are about to reset the following item(s):\n${selectedSummary}\n\nThis action cannot be undone. Continue?`,
-        { modal: true },
+        `Reset the following items:\n${selectedSummary}.\n This action cannot be undone. Continue?`,
         "Reset",
+        "Cancel",
     )
 
     if (confirmation !== "Reset") {
         return
     }
 
-    let processedCount = 0
-
     for (const item of selected) {
-        processedCount += await item.action.execute()
+        await item.action.execute()
     }
 
-    vscode.window.showInformationMessage(
-        `TSP Toolkit reset completed. Processed ${selected.length} selected reset item(s) and applied ${processedCount} change(s).`,
-    )
+    vscode.window.showInformationMessage("TSP Toolkit reset completed.")
 }
 
 export async function pickConnection(): Promise<Connection | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -834,12 +834,14 @@ async function resetToolkitDefaults() {
         canPickMany: true,
     })
 
-    if (!selected?.length) {
+    if (!selected || selected.length === 0) {
         return
     }
 
     //const selectedSummary = selected.map((item) => item.label).join(", ")
-    const selectedSummary = selected.map((item, index) => `${index + 1}. ${item.label}`).join(", ")
+    const selectedSummary = selected
+        .map((item, index) => `${index + 1}. ${item.label}`)
+        .join(", ")
 
     const confirmation = await vscode.window.showWarningMessage(
         `Reset the following items:\n${selectedSummary}.\n This action cannot be undone. Continue?`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -504,7 +504,7 @@ export function activate(context: vscode.ExtensionContext) {
             },
         },
         {
-            name: "tsp.resetToolkitDefaults",
+            name: "tsp.resetToDefaults",
             cb: async () => {
                 await resetToolkitDefaults()
             },
@@ -830,7 +830,7 @@ async function resetToolkitDefaults() {
     }))
 
     const selected = await vscode.window.showQuickPick(picks, {
-        title: "Reset TSP Toolkit",
+        title: "Reset to Defaults",
         canPickMany: true,
     })
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -834,7 +834,7 @@ async function resetToolkitDefaults() {
         canPickMany: true,
     })
 
-    if (!selected?.length) {
+    if (selected?.length <= 0) {
         return
     }
 


### PR DESCRIPTION
This PR adds a new "Reset to Defaults" workflow to the TSP Toolkit command palette, allowing users to selectively reset extension state and settings from a single entry point.

Changes:

- Added the "Reset to Defaults" command palette command.
- Added a multi-select checklist for choosing reset targets.
- Executes only the selected reset actions.
- Added a confirmation prompt before executing destructive actions.

Closes: [TSP-1588](https://jira.global.tektronix.net/jira/browse/TSP-1588)
