### PR TITLE
Improvements to command palette command behavior Reset to Defaults Part-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,6 +407,50 @@
                         }
                     }
                 },
+                "tsp.scriptGenSessions": {
+                    "type": "object",
+                    "scope": "window",
+                    "description": "Saved sessions for I-V Characterization script generation.",
+                    "properties": {
+                        "I-V Characterization": {
+                            "type": "array",
+                            "description": "Properties for I-V Characterization script generation.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "config": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tsp.triggerFlowSessions": {
+                    "type": "object",
+                    "scope": "window",
+                    "description": "Saved sessions for TriggerFlow.",
+                    "properties": {
+                        "Trigger Flow": {
+                            "type": "array",
+                            "description": "Properties for TriggerFlow sessions.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "config": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "tsp.lineFrequency": {
                     "type": "number",
                     "enum": [

--- a/src/baseSessionManager.ts
+++ b/src/baseSessionManager.ts
@@ -59,6 +59,8 @@ export abstract class BaseSessionManager<TDataProvider, TSessionInstance> {
     protected treeview?: vscode.TreeView<TSessionInstance>
     protected sessionName: string | undefined
     protected lastSentData: string | undefined
+    // Guard: prevents webview messages from writing back session data during deleteAll
+    private isDeletingAllSessions = false
 
     // Mapping of block names to manual URLs for the OPEN_MANUAL command
     // in future, this details we can keep catalog file?.
@@ -124,8 +126,8 @@ export abstract class BaseSessionManager<TDataProvider, TSessionInstance> {
         // Delete all sessions command
         const deleteAllCmd = vscode.commands.registerCommand(
             this.config.deleteAllCommandId,
-            () => {
-                this.deleteAllSessions()
+            async () => {
+                await this.deleteAllSessions()
             },
         )
         this.context.subscriptions.push(deleteAllCmd)
@@ -239,6 +241,11 @@ export abstract class BaseSessionManager<TDataProvider, TSessionInstance> {
      * Handle messages from webview
      */
     protected handleWebviewMessage(message: WebviewMessage): void {
+        // Drop all messages while a deleteAll is in progress to prevent
+        // the Rust process from writing sessions back after they were cleared
+        if (this.isDeletingAllSessions) {
+            return
+        }
         switch (message.command as WebviewCommandType) {
             case WebviewCommandType.OPEN_SCRIPT:
                 this.openGeneratedScript()
@@ -503,12 +510,17 @@ export abstract class BaseSessionManager<TDataProvider, TSessionInstance> {
     /**
      * Delete all sessions
      */
-    protected deleteAllSessions(): void {
-        if (this.panel) {
-            this.panel.dispose()
+    protected async deleteAllSessions(): Promise<void> {
+        this.isDeletingAllSessions = true
+        try {
+            if (this.panel) {
+                this.panel.dispose()
+            }
+            await this.removeAllSessions()
+            this.deleteAllDataProviderItems()
+        } finally {
+            this.isDeletingAllSessions = false
         }
-        this.removeAllSessions()
-        this.deleteAllDataProviderItems()
     }
 
     // Abstract methods to be implemented by subclasses
@@ -519,7 +531,7 @@ export abstract class BaseSessionManager<TDataProvider, TSessionInstance> {
     protected abstract saveSession(name: string, config: string): void
     protected abstract updateSession(name: string, config: string): void
     protected abstract removeSession(name: string): void
-    protected abstract removeAllSessions(): void
+    protected abstract removeAllSessions(): Promise<void>
     protected abstract getSessionConfig(name: string): string | undefined
     protected abstract sessionExists(name: string): boolean
     protected abstract refreshDataProvider(): void

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -802,7 +802,8 @@ function buildResetActions(): ResetAction[] {
         (s) =>
             s.key !== "tsp.savedInstruments" &&
             s.key !== "tsp.tspLinkSystemConfigurations" &&
-            s.key !== "tsp.script_generation",
+            s.key !== "tsp.scriptGenSessions" &&
+            s.key !== "tsp.triggerFlowSessions",
     )
 
     return [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -288,7 +288,7 @@ async function checkVersionAndShowAnnouncement(
 }
 
 // Called when the extension is activated.
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
     const LOGLOC: SourceLocation = { file: "extension.ts", func: "activate()" }
     Log.info("TSP Toolkit activating", LOGLOC)
 
@@ -546,11 +546,19 @@ export function activate(context: vscode.ExtensionContext) {
 
     activateTspDebug(context)
 
+    await GenericSessionStorage.migrateLegacySessions()
+
     // Script Generation and Trigger Flow setup with combined tree view
-    const scriptGenStorage = new GenericSessionStorage("I-V Characterization")
+    const scriptGenStorage = new GenericSessionStorage(
+        "I-V Characterization",
+        "scriptGenSessions",
+    )
     const scriptGenDataProvider = new ScriptGenDataProvider(scriptGenStorage)
 
-    const triggerFlowStorage = new GenericSessionStorage("Trigger Flow")
+    const triggerFlowStorage = new GenericSessionStorage(
+        "Trigger Flow",
+        "triggerFlowSessions",
+    )
     const triggerFlowDataProvider = new TriggerFlowDataProvider(
         triggerFlowStorage,
     )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -998,44 +998,23 @@ async function resetToolkitDefaults() {
     const executableItems = previewResults.filter(
         (r) => r.preview.shouldExecute,
     )
-    const skippedItems = previewResults.filter((r) => !r.preview.shouldExecute)
 
     if (executableItems.length === 0) {
-        const skippedSummary = skippedItems
-            .map(
-                (result, index) =>
-                    `${index + 1}. ${result.item.label}: ${result.preview.skipReason ?? "Already in default state."}`,
-            )
-            .join("\n")
-
-        await vscode.window.showInformationMessage(
-            `Nothing to reset.\n\nSkipped:\n${skippedSummary}`,
-        )
+        await vscode.window.showInformationMessage("Nothing to reset.")
         return
     }
 
-    const resetSummary = executableItems
+    const resetSummary = previewResults
         .map((result, index) => {
             const warningLine = result.preview.warningNote
-                ? `\n   - ${result.preview.warningNote}`
+                ? `\n    - ${result.preview.warningNote}`
                 : ""
             return `${index + 1}. ${result.item.label}${warningLine}`
         })
         .join("\n")
 
-    const skippedSummary = skippedItems
-        .map(
-            (result, index) =>
-                `${index + 1}. ${result.item.label}: ${result.preview.skipReason ?? "Already in default state."}`,
-        )
-        .join("\n")
-
-    const skippedSection = skippedSummary
-        ? `\n\nWill be skipped:\n${skippedSummary}`
-        : ""
-
     const confirmation = await vscode.window.showWarningMessage(
-        `The following items will be reset:\n\n${resetSummary}${skippedSection}\n\nThis action cannot be undone.`,
+        `The following items will be reset:\n\n${resetSummary}\n\nThis action cannot be undone.`,
         {
             modal: true,
             detail: "Do you want to continue?",
@@ -1051,13 +1030,7 @@ async function resetToolkitDefaults() {
         await result.item.action.execute()
     }
 
-    const completionSkippedSection = skippedSummary
-        ? `\n\nSkipped:\n${skippedSummary}`
-        : ""
-
-    vscode.window.showInformationMessage(
-        `TSP Toolkit reset completed.${completionSkippedSection}`,
-    )
+    vscode.window.showInformationMessage("TSP Toolkit reset completed.")
 }
 
 export async function pickConnection(): Promise<Connection | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,14 @@ interface ResetAction {
     label: string
     description: string
     detail?: string
+    preview(): ResetActionPreview | Promise<ResetActionPreview>
     execute(): Promise<void>
+}
+
+interface ResetActionPreview {
+    shouldExecute: boolean
+    skipReason?: string
+    warningNote?: string
 }
 
 interface ManifestConfigurationSection {
@@ -756,6 +763,16 @@ async function resetSettings(settings: ResettableSetting[]): Promise<void> {
     }
 }
 
+function hasConfiguredValue(key: string): boolean {
+    const inspect = vscode.workspace.getConfiguration().inspect(key)
+    return Boolean(
+        inspect &&
+            (inspect.globalValue !== undefined ||
+                inspect.workspaceValue !== undefined ||
+                inspect.workspaceFolderValue !== undefined),
+    )
+}
+
 // Return the serial numbers of saved instruments that have at least one connected terminal
 function getConnectedSavedSerialNumbers(): Set<string> {
     const connected = new Set<string>()
@@ -812,6 +829,32 @@ function buildResetActions(): ResetAction[] {
             label: "Saved Instruments",
             description:
                 "Delete saved instruments; instruments with active connections are kept",
+            preview: (): ResetActionPreview => {
+                const config = vscode.workspace.getConfiguration("tsp")
+                const saved = config.get<InstrInfo[]>("savedInstruments") ?? []
+
+                if (saved.length === 0) {
+                    return {
+                        shouldExecute: false,
+                        skipReason: "No saved instruments found.",
+                    }
+                }
+
+                const connectedSerials = getConnectedSavedSerialNumbers()
+                const removable = saved.filter(
+                    (instr) => !connectedSerials.has(instr.serial_number),
+                )
+
+                if (removable.length === 0) {
+                    return {
+                        shouldExecute: false,
+                        skipReason:
+                            "Only active saved instruments exist and are preserved.",
+                    }
+                }
+
+                return { shouldExecute: true }
+            },
             execute: async (): Promise<void> => {
                 await resetSavedInstrumentsPreservingActiveConnections()
             },
@@ -821,6 +864,21 @@ function buildResetActions(): ResetAction[] {
             id: "systemConfigurations",
             label: "Saved Instrument Configurations",
             description: "Reset saved instrument configurations",
+            preview: (): ResetActionPreview => {
+                const systems =
+                    vscode.workspace
+                        .getConfiguration("tsp")
+                        .get<unknown[]>("tspLinkSystemConfigurations") ?? []
+
+                if (systems.length === 0) {
+                    return {
+                        shouldExecute: false,
+                        skipReason: "No saved instrument configurations found.",
+                    }
+                }
+
+                return { shouldExecute: true }
+            },
             execute: async (): Promise<void> => {
                 await resetSettings(systemConfigurations)
             },
@@ -831,6 +889,21 @@ function buildResetActions(): ResetAction[] {
             label: "Other TSP Toolkit Preferences",
             description: "Reset remaining extension settings",
             detail: otherSettings.map((s) => s.label).join(", "),
+            preview: (): ResetActionPreview => {
+                const configuredSettings = otherSettings.filter((setting) =>
+                    hasConfiguredValue(setting.key),
+                )
+
+                if (configuredSettings.length === 0) {
+                    return {
+                        shouldExecute: false,
+                        skipReason:
+                            "All selected preferences are already at defaults.",
+                    }
+                }
+
+                return { shouldExecute: true }
+            },
             execute: async (): Promise<void> => {
                 await resetSettings(otherSettings)
             },
@@ -840,6 +913,24 @@ function buildResetActions(): ResetAction[] {
             id: "scriptGen",
             label: "Delete Script Generation Sessions",
             description: "Delete all Script Generation sessions",
+            preview: (): ResetActionPreview => {
+                const storage = new GenericSessionStorage(
+                    "I-V Characterization",
+                    "scriptGenSessions",
+                )
+                if (storage.getSessionCount() === 0) {
+                    return {
+                        shouldExecute: false,
+                        skipReason: "No Script Generation sessions found.",
+                    }
+                }
+
+                return {
+                    shouldExecute: true,
+                    warningNote:
+                        "Note: Active and saved sessions will be deleted.",
+                }
+            },
             execute: async (): Promise<void> => {
                 await vscode.commands.executeCommand(
                     "tsp.deleteAllScriptGenSessions",
@@ -851,6 +942,24 @@ function buildResetActions(): ResetAction[] {
             id: "triggerFlow",
             label: "Delete TriggerFlow Sessions",
             description: "Delete all TriggerFlow sessions",
+            preview: (): ResetActionPreview => {
+                const storage = new GenericSessionStorage(
+                    "Trigger Flow",
+                    "triggerFlowSessions",
+                )
+                if (storage.getSessionCount() === 0) {
+                    return {
+                        shouldExecute: false,
+                        skipReason: "No TriggerFlow sessions found.",
+                    }
+                }
+
+                return {
+                    shouldExecute: true,
+                    warningNote:
+                        "Note: Active and saved sessions will be deleted.",
+                }
+            },
             execute: async (): Promise<void> => {
                 await vscode.commands.executeCommand(
                     "tsp.deleteAllTriggerFlowSessions",
@@ -879,21 +988,54 @@ async function resetToolkitDefaults() {
         return
     }
 
-    //const selectedSummary = selected.map((item) => item.label).join(", ")
-    const selectedSummary = selected
-        .map((item, index) => {
-            const activeSessionWarning =
-                item.action.id === "scriptGen" ||
-                item.action.id === "triggerFlow"
-                    ? "\n   - Note: Active and saved sessions will be deleted."
-                    : ""
+    const previewResults = await Promise.all(
+        selected.map(async (item) => ({
+            item,
+            preview: await item.action.preview(),
+        })),
+    )
 
-            return `${index + 1}. ${item.label}${activeSessionWarning}`
+    const executableItems = previewResults.filter(
+        (r) => r.preview.shouldExecute,
+    )
+    const skippedItems = previewResults.filter((r) => !r.preview.shouldExecute)
+
+    if (executableItems.length === 0) {
+        const skippedSummary = skippedItems
+            .map(
+                (result, index) =>
+                    `${index + 1}. ${result.item.label}: ${result.preview.skipReason ?? "Already in default state."}`,
+            )
+            .join("\n")
+
+        await vscode.window.showInformationMessage(
+            `Nothing to reset.\n\nSkipped:\n${skippedSummary}`,
+        )
+        return
+    }
+
+    const resetSummary = executableItems
+        .map((result, index) => {
+            const warningLine = result.preview.warningNote
+                ? `\n   - ${result.preview.warningNote}`
+                : ""
+            return `${index + 1}. ${result.item.label}${warningLine}`
         })
         .join("\n")
 
+    const skippedSummary = skippedItems
+        .map(
+            (result, index) =>
+                `${index + 1}. ${result.item.label}: ${result.preview.skipReason ?? "Already in default state."}`,
+        )
+        .join("\n")
+
+    const skippedSection = skippedSummary
+        ? `\n\nWill be skipped:\n${skippedSummary}`
+        : ""
+
     const confirmation = await vscode.window.showWarningMessage(
-        `The following items will be reset:\n\n${selectedSummary}\n\nThis action cannot be undone.`,
+        `The following items will be reset:\n\n${resetSummary}${skippedSection}\n\nThis action cannot be undone.`,
         {
             modal: true,
             detail: "Do you want to continue?",
@@ -905,11 +1047,17 @@ async function resetToolkitDefaults() {
         return
     }
 
-    for (const item of selected) {
-        await item.action.execute()
+    for (const result of executableItems) {
+        await result.item.action.execute()
     }
 
-    vscode.window.showInformationMessage("TSP Toolkit reset completed.")
+    const completionSkippedSection = skippedSummary
+        ? `\n\nSkipped:\n${skippedSummary}`
+        : ""
+
+    vscode.window.showInformationMessage(
+        `TSP Toolkit reset completed.${completionSkippedSection}`,
+    )
 }
 
 export async function pickConnection(): Promise<Connection | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -881,13 +881,24 @@ async function resetToolkitDefaults() {
 
     //const selectedSummary = selected.map((item) => item.label).join(", ")
     const selectedSummary = selected
-        .map((item, index) => `${index + 1}. ${item.label}`)
-        .join(", ")
+        .map((item, index) => {
+            const activeSessionWarning =
+                item.action.id === "scriptGen" ||
+                item.action.id === "triggerFlow"
+                    ? "\n   - Note: Active and saved sessions will be deleted."
+                    : ""
+
+            return `${index + 1}. ${item.label}${activeSessionWarning}`
+        })
+        .join("\n")
 
     const confirmation = await vscode.window.showWarningMessage(
-        `Reset the following items:\n${selectedSummary}.\n This action cannot be undone. Continue?`,
+        `The following items will be reset:\n\n${selectedSummary}\n\nThis action cannot be undone.`,
+        {
+            modal: true,
+            detail: "Do you want to continue?",
+        },
         "Reset",
-        "Cancel",
     )
 
     if (confirmation !== "Reset") {

--- a/src/genericSessionStorage.ts
+++ b/src/genericSessionStorage.ts
@@ -153,10 +153,9 @@ export class GenericSessionStorage {
         const workspaceConfig = vscode.workspace.getConfiguration()
 
         // Nothing to migrate if legacy key doesn't exist
-        const legacyConfig =
-            workspaceConfig.get<SessionCollection>(
-                `tsp.${GenericSessionStorage.LEGACY_SETTINGS_KEY}`,
-            )
+        const legacyConfig = workspaceConfig.get<SessionCollection>(
+            `tsp.${GenericSessionStorage.LEGACY_SETTINGS_KEY}`,
+        )
 
         if (!legacyConfig || Object.keys(legacyConfig).length === 0) {
             return
@@ -175,7 +174,7 @@ export class GenericSessionStorage {
             `tsp.${GenericSessionStorage.TRIGGER_FLOW_SETTINGS_KEY}`,
         )
 
-        try{
+        try {
             if (!scriptGenConfig && ivSessions.length > 0) {
                 await workspaceConfig.update(
                     `tsp.${GenericSessionStorage.SCRIPT_GEN_SETTINGS_KEY}`,
@@ -195,18 +194,21 @@ export class GenericSessionStorage {
                     vscode.ConfigurationTarget.Workspace,
                 )
             }
-            
+
             // Remove legacy storage once migration succeeds
             await workspaceConfig.update(
                 `tsp.${GenericSessionStorage.LEGACY_SETTINGS_KEY}`,
                 undefined,
                 vscode.ConfigurationTarget.Workspace,
             )
-        }catch (error) {
+        } catch (error) {
             console.error("Failed to migrate legacy sessions:", error)
             Log.error(
-                `Failed to migrate legacy session storage: ${error}`,
-                { file: "genericSessionStorage.ts", func: "migrateLegacySessions()" },
+                `Failed to migrate legacy session storage: ${error instanceof Error ? error.message : String(error)}`,
+                {
+                    file: "genericSessionStorage.ts",
+                    func: "migrateLegacySessions()",
+                },
             )
         }
     }

--- a/src/genericSessionStorage.ts
+++ b/src/genericSessionStorage.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import { Log } from "./logging"
 
 /**
  * Represents a single session configuration
@@ -22,6 +23,9 @@ export interface SessionCollection {
 export class GenericSessionStorage {
     private readonly settingsKey: string
     private readonly sessionType: string
+    private static readonly LEGACY_SETTINGS_KEY = "script_generation"
+    private static readonly SCRIPT_GEN_SETTINGS_KEY = "scriptGenSessions"
+    private static readonly TRIGGER_FLOW_SETTINGS_KEY = "triggerFlowSessions"
 
     constructor(sessionType: string, settingsKey = "script_generation") {
         this.sessionType = sessionType
@@ -143,6 +147,68 @@ export class GenericSessionStorage {
         vscode.workspace
             .getConfiguration("tsp")
             .update(this.settingsKey, sessions, false)
+    }
+
+    public static async migrateLegacySessions(): Promise<void> {
+        const workspaceConfig = vscode.workspace.getConfiguration()
+
+        // Nothing to migrate if legacy key doesn't exist
+        const legacyConfig =
+            workspaceConfig.get<SessionCollection>(
+                `tsp.${GenericSessionStorage.LEGACY_SETTINGS_KEY}`,
+            )
+
+        if (!legacyConfig || Object.keys(legacyConfig).length === 0) {
+            return
+        }
+
+        const ivSessions = legacyConfig["I-V Characterization"] ?? []
+        const triggerFlowSessions = legacyConfig["Trigger Flow"] ?? []
+
+        // If either new key already exists, assume migration has already
+        // been performed (or the user has started using the new version).
+        const scriptGenConfig = workspaceConfig.get<SessionCollection>(
+            `tsp.${GenericSessionStorage.SCRIPT_GEN_SETTINGS_KEY}`,
+        )
+
+        const triggerFlowConfig = workspaceConfig.get<SessionCollection>(
+            `tsp.${GenericSessionStorage.TRIGGER_FLOW_SETTINGS_KEY}`,
+        )
+
+        try{
+            if (!scriptGenConfig && ivSessions.length > 0) {
+                await workspaceConfig.update(
+                    `tsp.${GenericSessionStorage.SCRIPT_GEN_SETTINGS_KEY}`,
+                    {
+                        "I-V Characterization": ivSessions,
+                    },
+                    vscode.ConfigurationTarget.Workspace,
+                )
+            }
+
+            if (!triggerFlowConfig && triggerFlowSessions.length > 0) {
+                await workspaceConfig.update(
+                    `tsp.${GenericSessionStorage.TRIGGER_FLOW_SETTINGS_KEY}`,
+                    {
+                        "Trigger Flow": triggerFlowSessions,
+                    },
+                    vscode.ConfigurationTarget.Workspace,
+                )
+            }
+            
+            // Remove legacy storage once migration succeeds
+            await workspaceConfig.update(
+                `tsp.${GenericSessionStorage.LEGACY_SETTINGS_KEY}`,
+                undefined,
+                vscode.ConfigurationTarget.Workspace,
+            )
+        }catch (error) {
+            console.error("Failed to migrate legacy sessions:", error)
+            Log.error(
+                `Failed to migrate legacy session storage: ${error}`,
+                { file: "genericSessionStorage.ts", func: "migrateLegacySessions()" },
+            )
+        }
     }
 }
 

--- a/src/genericSessionStorage.ts
+++ b/src/genericSessionStorage.ts
@@ -75,7 +75,7 @@ export class GenericSessionStorage {
 
         existingSessions[this.sessionType].push(newSession)
 
-        this.updateSettings(existingSessions)
+        void this.updateSettings(existingSessions)
     }
 
     /**
@@ -92,14 +92,12 @@ export class GenericSessionStorage {
 
         if (currentSession) {
             currentSession.config = updatedConfig
-            try {
-                this.updateSettings(existingSessions)
-            } catch (error) {
+            void this.updateSettings(existingSessions).catch((error) => {
                 console.error(
                     `Failed to update ${this.sessionType} settings:`,
                     error,
                 )
-            }
+            })
         }
     }
 
@@ -113,16 +111,16 @@ export class GenericSessionStorage {
             existingSessions[this.sessionType] || []
         ).filter((session) => session.name !== name)
 
-        this.updateSettings(existingSessions)
+        void this.updateSettings(existingSessions)
     }
 
     /**
      * Remove all sessions of this type
      */
-    removeAllSessions(): void {
+    removeAllSessions(): Promise<void> {
         const existingSessions = this.loadSessions()
         existingSessions[this.sessionType] = []
-        this.updateSettings(existingSessions)
+        return this.updateSettings(existingSessions)
     }
 
     /**
@@ -143,10 +141,12 @@ export class GenericSessionStorage {
     /**
      * Update workspace settings
      */
-    private updateSettings(sessions: SessionCollection): void {
-        vscode.workspace
-            .getConfiguration("tsp")
-            .update(this.settingsKey, sessions, false)
+    private updateSettings(sessions: SessionCollection): Promise<void> {
+        return Promise.resolve(
+            vscode.workspace
+                .getConfiguration("tsp")
+                .update(this.settingsKey, sessions, false),
+        )
     }
 
     public static async migrateLegacySessions(): Promise<void> {

--- a/src/scriptGenWebViewManager.ts
+++ b/src/scriptGenWebViewManager.ts
@@ -57,7 +57,10 @@ export class ScriptGenWebViewManager extends BaseSessionManager<
 
         super(context, config, dataProvider)
 
-        this.storage = new GenericSessionStorage("I-V Characterization")
+        this.storage = new GenericSessionStorage(
+            "I-V Characterization",
+            "scriptGenSessions",
+        )
         this.validator = new SessionNameValidator(this.storage)
     }
 

--- a/src/scriptGenWebViewManager.ts
+++ b/src/scriptGenWebViewManager.ts
@@ -236,8 +236,8 @@ export class ScriptGenWebViewManager extends BaseSessionManager<
     /**
      * Remove all sessions
      */
-    protected removeAllSessions(): void {
-        this.storage.removeAllSessions()
+    protected removeAllSessions(): Promise<void> {
+        return this.storage.removeAllSessions()
     }
 
     /**

--- a/src/triggerFlowWebViewManager.ts
+++ b/src/triggerFlowWebViewManager.ts
@@ -219,8 +219,8 @@ export class TriggerFlowWebViewManager extends BaseSessionManager<
     /**
      * Remove all sessions
      */
-    protected removeAllSessions(): void {
-        this.storage.removeAllSessions()
+    protected removeAllSessions(): Promise<void> {
+        return this.storage.removeAllSessions()
     }
 
     /**

--- a/src/triggerFlowWebViewManager.ts
+++ b/src/triggerFlowWebViewManager.ts
@@ -57,7 +57,10 @@ export class TriggerFlowWebViewManager extends BaseSessionManager<
 
         super(context, config, dataProvider)
 
-        this.storage = new GenericSessionStorage("Trigger Flow")
+        this.storage = new GenericSessionStorage(
+            "Trigger Flow",
+            "triggerFlowSessions",
+        )
         this.validator = new SessionNameValidator(this.storage)
     }
 


### PR DESCRIPTION
- Split Script Generation and Trigger Flow session storage into dedicated configuration keys.
- Added one-time migration from the legacy shared session storage during extension activation, preserving existing user sessions.
- Removed the legacy configuration key after successful migration to prevent stale or duplicate data.
- Replaced the reset confirmation notification with a modal warning dialog.
- Added inline warnings in the confirmation dialog when selected reset actions will delete active Script Generation or Trigger Flow sessions.

Closes: [TSP-1588](https://jira.global.tektronix.net/jira/browse/TSP-1588)