### PR TITLE
Improve Reset to Defaults flow and notifications

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -819,6 +819,7 @@ function buildResetActions(): ResetAction[] {
         (s) =>
             s.key !== "tsp.savedInstruments" &&
             s.key !== "tsp.tspLinkSystemConfigurations" &&
+            s.key !== "tsp.script_generation" &&
             s.key !== "tsp.scriptGenSessions" &&
             s.key !== "tsp.triggerFlowSessions",
     )
@@ -999,11 +1000,11 @@ async function resetToolkitDefaults() {
         (r) => r.preview.shouldExecute,
     )
 
-    if (executableItems.length === 0) {
-        await vscode.window.showInformationMessage("Nothing to reset.")
-        return
-    }
-
+    // if (executableItems.length === 0) {
+    //     await vscode.window.showInformationMessage("Nothing to reset.")
+    //     return
+    // }
+    
     const resetSummary = previewResults
         .map((result, index) => {
             const warningLine = result.preview.warningNote
@@ -1029,8 +1030,8 @@ async function resetToolkitDefaults() {
     for (const result of executableItems) {
         await result.item.action.execute()
     }
-
-    vscode.window.showInformationMessage("TSP Toolkit reset completed.")
+    
+    vscode.window.showInformationMessage("Reset completed successfully.")
 }
 
 export async function pickConnection(): Promise<Connection | undefined> {


### PR DESCRIPTION
Improved Reset to Defaults flow and notifications with below changes:
- Removed tsp.script_generation from preferences reset list
- Removed misleading "Nothing to reset" notification
- Updated reset completion message

Closes: 
[TSP-1929](https://jira.global.tektronix.net/jira/browse/TSP-1929)
[TSP-1939](https://jira.global.tektronix.net/jira/browse/TSP-1939)
