### PR TITLE
Enhance session migration logic to handle legacy storage more robustly

### DIFF
--- a/src/genericSessionStorage.ts
+++ b/src/genericSessionStorage.ts
@@ -175,32 +175,54 @@ export class GenericSessionStorage {
         )
 
         try {
-            if (!scriptGenConfig && ivSessions.length > 0) {
-                await workspaceConfig.update(
-                    `tsp.${GenericSessionStorage.SCRIPT_GEN_SETTINGS_KEY}`,
+            let migratedScriptGen = false
+            let migratedTriggerFlow = false
+
+            // Check if the target keys already have real sessions (not just empty containers).
+            // An object like { "I-V Characterization": [] } has keys but no sessions,
+            // so migration should still run in that case.
+            const scriptGenHasSessions =
+                (scriptGenConfig?.["I-V Characterization"]?.length ?? 0) > 0
+            const triggerFlowHasSessions =
+                (triggerFlowConfig?.["Trigger Flow"]?.length ?? 0) > 0
+
+            if (!scriptGenHasSessions && ivSessions.length > 0) {
+                await vscode.workspace.getConfiguration("tsp").update(
+                    GenericSessionStorage.SCRIPT_GEN_SETTINGS_KEY,
                     {
                         "I-V Characterization": ivSessions,
                     },
-                    vscode.ConfigurationTarget.Workspace,
+                    false,
                 )
+                migratedScriptGen = true
             }
 
-            if (!triggerFlowConfig && triggerFlowSessions.length > 0) {
-                await workspaceConfig.update(
-                    `tsp.${GenericSessionStorage.TRIGGER_FLOW_SETTINGS_KEY}`,
+            if (!triggerFlowHasSessions && triggerFlowSessions.length > 0) {
+                await vscode.workspace.getConfiguration("tsp").update(
+                    GenericSessionStorage.TRIGGER_FLOW_SETTINGS_KEY,
                     {
                         "Trigger Flow": triggerFlowSessions,
                     },
-                    vscode.ConfigurationTarget.Workspace,
+                    false,
                 )
+                migratedTriggerFlow = true
             }
 
-            // Remove legacy storage once migration succeeds
-            await workspaceConfig.update(
-                `tsp.${GenericSessionStorage.LEGACY_SETTINGS_KEY}`,
-                undefined,
-                vscode.ConfigurationTarget.Workspace,
-            )
+            // Remove legacy storage when all session types have been accounted for:
+            // either migrated in this run, or already present in the new keys, or
+            // there were no sessions to migrate for that type.
+            const scriptGenAccountedFor =
+                migratedScriptGen || scriptGenHasSessions || ivSessions.length === 0
+            const triggerFlowAccountedFor =
+                migratedTriggerFlow || triggerFlowHasSessions || triggerFlowSessions.length === 0
+
+            if (scriptGenAccountedFor && triggerFlowAccountedFor) {
+                await vscode.workspace.getConfiguration("tsp").update(
+                    GenericSessionStorage.LEGACY_SETTINGS_KEY,
+                    undefined,
+                    false,
+                )
+            }
         } catch (error) {
             console.error("Failed to migrate legacy sessions:", error)
             Log.error(


### PR DESCRIPTION
Ensure sessions migrate from legacy configuration and legacy cleanup

- Check actual session count instead of object key count before skipping migration
- Clean up legacy config once all session types are accounted for

Closes: [TSP-1931](https://jira.global.tektronix.net/jira/browse/TSP-1931)
