### PR TITLE
Add configurable connection timeout as a VS Code setting for instrument connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - TSP language interop feature.
 - **tsp-toolkit-language-interop** - Implement tsp language interop feature
-
+- Added configurable 'Connection Timeout' as a VS Code setting for instrument connections.
 
 
 ## [1.5.1]

--- a/package.json
+++ b/package.json
@@ -364,6 +364,13 @@
                     "description": "Clear error queue on connection.",
                     "scope": "application"
                 },
+                "tsp.connectionTimeout": {
+                    "type": "number",
+                    "default": 30,
+                    "minimum": 0,
+                    "description": "Maximum time, in seconds, to wait for an instrument connection to complete before it is cancelled and the user is notified. Set to 0 to disable the timeout.",
+                    "scope": "application"
+                },
                 "tsp.tspLinkSystemConfigurations": {
                     "type": "array",
                     "default": [],

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -91,6 +91,7 @@ export function statusToString(status: ConnectionStatus | undefined): string {
             return "Connected"
     }
 }
+
 export function contextValueStatus(
     contextValue: string,
     status: ConnectionStatus | undefined,
@@ -138,25 +139,15 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         this.status = ConnectionStatus.Inactive
         this.enable(true)
     }
+
     dispose() {
         if (this._terminal) {
             this._terminal.dispose()
+            this._terminal = undefined
         }
-        if (this._background_process) {
-            if (os.platform() === "win32" && this._background_process.pid) {
-                // The following was the only configuration of options found to work.
-                // Do NOT remove the `/F` unless you have rigorously proven that it
-                // consistently works.
-                child.spawnSync("TaskKill", [
-                    "/PID",
-                    this._background_process.pid.toString(),
-                    "/T", // Terminate the specified process and any child processes
-                    "/F", // Forcefully terminate the specified processes
-                ])
-            } else {
-                this._background_process.kill("SIGINT")
-            }
-        }
+
+        this.terminateBackgroundProcess(this._background_process)
+        this._onChangedStatus.dispose()
     }
 
     enable(enable: boolean) {
@@ -221,44 +212,87 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
     }
 
     /**
-     * Combine multiple cancellation tokens into a single token.
+     * Combine multiple cancellation tokens into one token.
      *
-     * The returned token is cancelled as soon as any one of the input tokens
-     * is cancelled.
+     * The returned disposable must be disposed when the combined token is no
+     * longer required. This prevents cancellation event listeners from leaking.
      */
     private static combineCancellationTokens(
         ...tokens: vscode.CancellationToken[]
-    ): vscode.CancellationToken {
-        const combinedSource = new vscode.CancellationTokenSource()
+    ): {
+        token: vscode.CancellationToken
+        dispose: () => void
+    } {
+        const source = new vscode.CancellationTokenSource()
+        const disposables: vscode.Disposable[] = []
+
+        const cancel = () => {
+            if (!source.token.isCancellationRequested) {
+                source.cancel()
+            }
+        }
 
         for (const token of tokens) {
             if (token.isCancellationRequested) {
-                combinedSource.cancel()
+                cancel()
+                break
             }
 
-            token.onCancellationRequested(() => combinedSource.cancel())
+            disposables.push(token.onCancellationRequested(cancel))
         }
 
-        return combinedSource.token
+        return {
+            token: source.token,
+            dispose: () => {
+                for (const disposable of disposables) {
+                    disposable.dispose()
+                }
+
+                disposables.length = 0
+                source.dispose()
+            },
+        }
     }
 
-    private terminateBackgroundProcessOnCancel() {
-        if (!this._background_process) {
+    /**
+     * Terminate a specific background process.
+     *
+     * The process is cleared from _background_process only if it is still the
+     * process currently owned by this Connection. This prevents an old
+     * timeout/callback from accidentally clearing or terminating a newer
+     * process.
+     */
+    private terminateBackgroundProcess(
+        process: child.ChildProcess | undefined,
+    ): void {
+        if (!process) {
             return
         }
 
-        if (os.platform() === "win32" && this._background_process.pid) {
+        if (os.platform() === "win32" && process.pid) {
+            // The following was the only configuration of options found to work.
+            // Do NOT remove the `/F` unless you have rigorously proven that it
+            // consistently works.
             child.spawnSync("TaskKill", [
                 "/PID",
-                this._background_process.pid.toString(),
+                process.pid.toString(),
                 "/T",
                 "/F",
             ])
-        } else {
-            this._background_process.kill("SIGINT")
+        } else if (!process.killed) {
+            process.kill("SIGINT")
         }
 
-        this._background_process = undefined
+        if (this._background_process === process) {
+            this._background_process = undefined
+        }
+    }
+
+    /**
+     * Terminate the currently active background process.
+     */
+    private terminateBackgroundProcessOnCancel(): void {
+        this.terminateBackgroundProcess(this._background_process)
     }
 
     /**
@@ -279,12 +313,17 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         orig_status: ConnectionStatus | undefined,
         LOGLOC: { file: string; func: string },
     ): Promise<boolean> {
-        const timeoutSeconds = vscode.workspace
+        const configuredTimeout = vscode.workspace
             .getConfiguration("tsp")
             .get<number>("connectionTimeout", 30)
 
-        // A timeout of 0 (or an invalid value) disables the timeout entirely
-        if (!timeoutSeconds || timeoutSeconds <= 0) {
+        const timeoutSeconds =
+            Number.isFinite(configuredTimeout) && configuredTimeout >= 0
+                ? configuredTimeout
+                : 30
+
+        // A timeout of 0 explicitly disables the connection timeout.
+        if (timeoutSeconds === 0) {
             return this.runConnectFlow(
                 name,
                 progress,
@@ -295,6 +334,11 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         }
 
         const timeoutSource = new vscode.CancellationTokenSource()
+
+        const combined = Connection.combineCancellationTokens(
+            cancel,
+            timeoutSource.token,
+        )
 
         const timeoutHandle = setTimeout(() => {
             // If the user already cancelled, don't report a timeout.
@@ -314,22 +358,17 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             timeoutSource.cancel()
         }, timeoutSeconds * 1000)
 
-        const combinedToken = Connection.combineCancellationTokens(
-            cancel,
-            timeoutSource.token,
-        )
-
         try {
             return await this.runConnectFlow(
                 name,
                 progress,
-                combinedToken,
+                combined.token,
                 orig_status,
                 LOGLOC,
             )
         } finally {
             clearTimeout(timeoutHandle)
-            timeoutSource.dispose()
+            combined.dispose()
         }
     }
 
@@ -357,10 +396,11 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         //await new Promise((resolve) => setTimeout(resolve, 3000))
 
         cancel.onCancellationRequested(() => {
-            Log.info("Connection cancelled by user", LOGLOC)
+            Log.info("Connection attempt cancelled", LOGLOC)
             this.terminateBackgroundProcessOnCancel()
             this.status = orig_status
         })
+
         if (cancelIfRequested()) {
             return false
         }
@@ -436,6 +476,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                 if (this._keyring) {
                     break
                 }
+
                 if (
                     (this._keyring === undefined || this._keyring === null) &&
                     i < 3
@@ -448,9 +489,10 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                         LOGLOC,
                     )
                 }
+
                 if (
                     (this._keyring === undefined || this._keyring === null) &&
-                    i == 3
+                    i === 3
                 ) {
                     vscode.window.showErrorMessage(
                         `Unable to connect to instrument at ${this._addr}, please check your credentials and try again.`,
@@ -474,10 +516,12 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             this.status = orig_status
             return false
         }
+
         //Get instrument info
         progress.report({
             message: "Getting instrument information",
         })
+
         if (cancelIfRequested()) {
             return false
         }
@@ -516,7 +560,6 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         if (cancelIfRequested()) {
             return false
         }
-        //this.status = ConnectionStatus.Connected
 
         const additional_terminal_args: string[] = []
 
@@ -547,10 +590,8 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             this.addr,
         ]
 
-        if (additional_terminal_args) {
-            for (const a of additional_terminal_args) {
-                terminal_args.push(a)
-            }
+        for (const a of additional_terminal_args) {
+            terminal_args.push(a)
         }
 
         if (this._keyring) {
@@ -569,6 +610,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         }
 
         Log.debug("Starting VSCode Terminal", LOGLOC)
+
         this._terminal = vscode.window.createTerminal({
             name: this._parent.name,
             shellPath: EXECUTABLE,
@@ -596,11 +638,11 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             },
         })
 
-        this._terminal?.show(false)
+        this._terminal.show(false)
 
         // Handle cancellation after terminal is created
         if (cancelIfRequested()) {
-            this._terminal?.dispose()
+            this._terminal.dispose()
             this._terminal = undefined
             return false
         }
@@ -609,6 +651,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
 
         vscode.window.onDidCloseTerminal((t) => {
             Log.info("Terminal closed", LOGLOC)
+
             if (
                 t.creationOptions.iconPath !== undefined &&
                 // eslint-disable-next-line @typescript-eslint/no-base-to-string
@@ -647,6 +690,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connection.checkLogin()",
         }
+
         Log.debug("Checking if instrument requires login", LOGLOC)
 
         const backgroundProcess = child.spawn(
@@ -664,93 +708,104 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                 env: { CLICOLOR: "1", CLICOLOR_FORCE: "1" },
             },
         )
+
         this._background_process = backgroundProcess
-        if (timeout_ms) {
-            setTimeout(() => {
-                if (
-                    os.platform() === "win32" &&
-                    this._background_process?.pid
-                ) {
-                    // The following was the only configuration of options found to work.
-                    // Do NOT remove the `/F` unless you have rigorously proven that it
-                    // consistently works.
-                    child.spawnSync("TaskKill", [
-                        "/PID",
-                        this._background_process.pid.toString(),
-                        "/T", // Terminate the specified process and any child processes
-                        "/F", // Forcefully terminate the specified processes
-                    ])
-                } else {
-                    this._background_process?.kill("SIGINT")
+
+        let timeoutHandle: NodeJS.Timeout | undefined
+
+        if (timeout_ms !== undefined && timeout_ms > 0) {
+            timeoutHandle = setTimeout(() => {
+                if (this._background_process === backgroundProcess) {
+                    this.terminateBackgroundProcess(backgroundProcess)
                 }
             }, timeout_ms)
         }
-        const requirements = await new Promise<LoginStatus>((resolve) => {
-            let data = ""
-            backgroundProcess.stderr?.on("data", (chunk) => {
-                Log.trace(`Info stderr: ${chunk}`, LOGLOC)
-            })
-            backgroundProcess.stdout?.on("data", (chunk) => {
-                data += chunk
-            })
-            backgroundProcess.on("exit", (code) => {
-                if (code === 0) {
+
+        try {
+            const requirements = await new Promise<LoginStatus>((resolve) => {
+                let data = ""
+
+                backgroundProcess.stderr?.on("data", (chunk) => {
+                    Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+                })
+
+                backgroundProcess.stdout?.on("data", (chunk) => {
+                    data += chunk
+                })
+
+                backgroundProcess.on("exit", (code) => {
+                    if (code === 0) {
+                        resolve({ type: "NotPrompted" })
+                        return
+                    }
+
+                    if (code === 2) {
+                        resolve({ type: "InUse" })
+                        return
+                    }
+
+                    if (code === 3 || code === 4) {
+                        const ret: {
+                            username: boolean
+                            password: boolean
+                            keyring?: string
+                        } = {
+                            username: false,
+                            password: false,
+                            keyring: undefined,
+                        }
+
+                        const d = data.toString()
+                        const [, details] = d.split(": ")
+
+                        if (details) {
+                            const reqs = details.split(",")
+
+                            if (
+                                (reqs.length > 1 &&
+                                    d.search(/USERNAME/g) === -1) ||
+                                reqs.length > 2
+                            ) {
+                                ret.keyring = reqs[reqs.length - 1].trim()
+                            }
+                        }
+
+                        ret.password = true
+
+                        if (d.search(/USERNAME/g) !== -1) {
+                            ret.username = true
+                        }
+
+                        resolve({
+                            type: "Protected",
+                            username: ret.username,
+                            password: ret.password,
+                            keyring: ret.keyring,
+                        })
+                        return
+                    }
+
                     resolve({ type: "NotPrompted" })
-                    return
-                }
-                if (code === 2) {
-                    resolve({ type: "InUse" })
-                    return
-                }
-                if (code === 3 || code === 4) {
-                    const ret: {
-                        username: boolean
-                        password: boolean
-                        keyring?: string
-                    } = {
-                        username: false,
-                        password: false,
-                        keyring: undefined,
-                    }
-                    const d = data.toString()
-                    const [, details] = d.split(": ")
-                    const reqs = details.split(",")
-                    if (
-                        (reqs.length > 1 && d.search(/USERNAME/g) === -1) ||
-                        reqs.length > 2
-                    ) {
-                        ret.keyring = reqs[reqs.length - 1].trim()
-                    }
-
-                    ret.password = true
-                    if (d.search(/USERNAME/g) !== -1) {
-                        ret.username = true
-                    }
-                    resolve({
-                        type: "Protected",
-                        username: ret.username,
-                        password: ret.password,
-                        keyring: ret.keyring,
-                    })
-                    return
-                }
-                resolve({ type: "NotPrompted" })
-                return
+                })
             })
-        })
 
-        const exit_code = backgroundProcess.exitCode
+            const exit_code = backgroundProcess.exitCode
 
-        if (this._background_process === backgroundProcess) {
-            this._background_process = undefined
+            Log.trace(
+                `Info process exited with code: ${exit_code}, requirements: ${JSON.stringify(requirements)}`,
+                LOGLOC,
+            )
+
+            return requirements
+        } finally {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle)
+            }
+
+            if (this._background_process === backgroundProcess) {
+                this._background_process = undefined
+            }
         }
-
-        Log.trace(
-            `Info process exited with code: ${exit_code}, requirements: ${JSON.stringify(requirements)}`,
-            LOGLOC,
-        )
-
-        return requirements
     }
 
     async promptDetails(reqs: {
@@ -762,6 +817,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connection.promptDetails()",
         }
+
         Log.debug("Prompting user for login details", LOGLOC)
 
         const credentials: {
@@ -773,6 +829,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             password: undefined,
             keyring: undefined,
         }
+
         if (reqs.keyring) {
             credentials.keyring = reqs.keyring
             return credentials
@@ -811,7 +868,11 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         password?: string
         keyring?: string
     }): Promise<string | null | undefined> {
-        const LOGLOC = { file: "instruments.ts", func: "Connection.login()" }
+        const LOGLOC = {
+            file: "instruments.ts",
+            func: "Connection.login()",
+        }
+
         Log.debug("Logging into instrument", LOGLOC)
 
         const args = [
@@ -823,6 +884,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             "login",
             this.addr,
         ]
+
         if (credentials.keyring) {
             args.push("--keyring", credentials.keyring)
         } else {
@@ -842,45 +904,55 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         const backgroundProcess = child.spawn(EXECUTABLE, args, {
             env: { CLICOLOR: "1", CLICOLOR_FORCE: "1" },
         })
+
         this._background_process = backgroundProcess
 
-        const keyring_id = await new Promise<string>((resolve) => {
-            let data = ""
-            backgroundProcess.stderr?.on("data", (chunk) => {
-                Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+        try {
+            const keyring_id = await new Promise<string>((resolve) => {
+                let data = ""
+
+                backgroundProcess.stderr?.on("data", (chunk) => {
+                    Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+                })
+
+                backgroundProcess.stdout?.on("data", (chunk) => {
+                    data += chunk
+                })
+
+                backgroundProcess.on("close", () => {
+                    resolve(data.trim())
+                })
             })
-            backgroundProcess.stdout?.on("data", (chunk) => {
-                data += chunk
-            })
-            backgroundProcess.on("close", () => {
-                resolve(data.trim())
-            })
-        })
 
-        const exit_code = backgroundProcess.exitCode
+            const exit_code = backgroundProcess.exitCode
 
-        if (this._background_process === backgroundProcess) {
-            this._background_process = undefined
-        }
-
-        Log.trace(
-            `Login process exited with code: ${exit_code}, information: ${keyring_id.trim()}`,
-            LOGLOC,
-        )
-
-        if (keyring_id === "") {
-            Log.error(
-                "Unable to get keyring id after logging into instrument.",
+            Log.trace(
+                `Login process exited with code: ${exit_code}, information: ${keyring_id.trim()}`,
                 LOGLOC,
             )
-            return undefined
-        }
 
-        return keyring_id
+            if (keyring_id === "") {
+                Log.error(
+                    "Unable to get keyring id after logging into instrument.",
+                    LOGLOC,
+                )
+                return undefined
+            }
+
+            return keyring_id
+        } finally {
+            if (this._background_process === backgroundProcess) {
+                this._background_process = undefined
+            }
+        }
     }
 
     async ping(timeout_ms?: number): Promise<IIDNInfo | null> {
-        const LOGLOC = { file: "instruments.ts", func: "Connection.ping()" }
+        const LOGLOC = {
+            file: "instruments.ts",
+            func: "Connection.ping()",
+        }
+
         Log.debug("Getting instrument information", LOGLOC)
 
         const args = [
@@ -901,71 +973,78 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         const backgroundProcess = child.spawn(EXECUTABLE, args, {
             env: { CLICOLOR: "1", CLICOLOR_FORCE: "1" },
         })
+
         this._background_process = backgroundProcess
-        if (timeout_ms) {
-            setTimeout(() => {
-                if (
-                    os.platform() === "win32" &&
-                    this._background_process?.pid
-                ) {
-                    // The following was the only configuration of options found to work.
-                    // Do NOT remove the `/F` unless you have rigorously proven that it
-                    // consistently works.
-                    child.spawnSync("TaskKill", [
-                        "/PID",
-                        this._background_process.pid.toString(),
-                        "/T", // Terminate the specified process and any child processes
-                        "/F", // Forcefully terminate the specified processes
-                    ])
-                } else {
-                    this._background_process?.kill("SIGINT")
+
+        let timeoutHandle: NodeJS.Timeout | undefined
+
+        if (timeout_ms !== undefined && timeout_ms > 0) {
+            timeoutHandle = setTimeout(() => {
+                if (this._background_process === backgroundProcess) {
+                    this.terminateBackgroundProcess(backgroundProcess)
                 }
             }, timeout_ms)
         }
-        const info_string = await new Promise<string | null>((resolve) => {
-            let data = ""
-            backgroundProcess.stderr?.on("data", (chunk) => {
-                Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+
+        try {
+            const info_string = await new Promise<string | null>((resolve) => {
+                let data = ""
+
+                backgroundProcess.stderr?.on("data", (chunk) => {
+                    Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+                })
+
+                backgroundProcess.stdout?.on("data", (chunk) => {
+                    data += chunk
+                })
+
+                backgroundProcess.on("close", (code) => {
+                    if (code === 0) {
+                        resolve(data)
+                        return
+                    }
+
+                    resolve(null)
+                })
             })
-            backgroundProcess.stdout?.on("data", (chunk) => {
-                data += chunk
-            })
-            backgroundProcess.on("close", (code) => {
-                if (code === 0) {
-                    resolve(data)
-                }
-                resolve(null)
-            })
-        })
 
-        if (!info_string) {
-            return null
-        }
+            if (!info_string) {
+                return null
+            }
 
-        const exit_code = backgroundProcess.exitCode
+            const exit_code = backgroundProcess.exitCode
 
-        if (this._background_process === backgroundProcess) {
-            this._background_process = undefined
-        }
-
-        Log.trace(
-            `Info process exited with code: ${exit_code}, information: ${info_string.trim()}`,
-            LOGLOC,
-        )
-
-        if (info_string === "") {
-            Log.error(
-                "Unable to connect to instrument, could not get instrument information",
+            Log.trace(
+                `Info process exited with code: ${exit_code}, information: ${info_string.trim()}`,
                 LOGLOC,
             )
-            return null
-        }
 
-        return <IIDNInfo>JSON.parse(info_string)
+            if (info_string === "") {
+                Log.error(
+                    "Unable to connect to instrument, could not get instrument information",
+                    LOGLOC,
+                )
+                return null
+            }
+
+            return <IIDNInfo>JSON.parse(info_string)
+        } finally {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle)
+            }
+
+            if (this._background_process === backgroundProcess) {
+                this._background_process = undefined
+            }
+        }
     }
 
     async getInfo(timeout_ms?: number): Promise<IIDNInfo | null> {
-        const LOGLOC = { file: "instruments.ts", func: "Connection.getInfo()" }
+        const LOGLOC = {
+            file: "instruments.ts",
+            func: "Connection.getInfo()",
+        }
+
         Log.debug("Getting instrument information", LOGLOC)
 
         const args = [
@@ -983,60 +1062,64 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             args.push("--keyring", this._keyring)
         }
 
-        this._background_process = child.spawn(EXECUTABLE, args, {
+        const backgroundProcess = child.spawn(EXECUTABLE, args, {
             env: { CLICOLOR: "1", CLICOLOR_FORCE: "1" },
         })
-        if (timeout_ms) {
-            setTimeout(() => {
-                if (
-                    os.platform() === "win32" &&
-                    this._background_process?.pid
-                ) {
-                    // The following was the only configuration of options found to work.
-                    // Do NOT remove the `/F` unless you have rigorously proven that it
-                    // consistently works.
-                    child.spawnSync("TaskKill", [
-                        "/PID",
-                        this._background_process.pid.toString(),
-                        "/T", // Terminate the specified process and any child processes
-                        "/F", // Forcefully terminate the specified processes
-                    ])
-                } else {
-                    this._background_process?.kill("SIGINT")
+
+        this._background_process = backgroundProcess
+
+        let timeoutHandle: NodeJS.Timeout | undefined
+
+        if (timeout_ms !== undefined && timeout_ms > 0) {
+            timeoutHandle = setTimeout(() => {
+                if (this._background_process === backgroundProcess) {
+                    this.terminateBackgroundProcess(backgroundProcess)
                 }
             }, timeout_ms)
         }
-        const info_string = await new Promise<string>((resolve) => {
-            let data = ""
-            this._background_process?.stderr?.on("data", (chunk) => {
-                Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+
+        try {
+            const info_string = await new Promise<string>((resolve) => {
+                let data = ""
+
+                backgroundProcess.stderr?.on("data", (chunk) => {
+                    Log.trace(`Info stderr: ${chunk}`, LOGLOC)
+                })
+
+                backgroundProcess.stdout?.on("data", (chunk) => {
+                    data += chunk
+                })
+
+                backgroundProcess.on("close", () => {
+                    resolve(data)
+                })
             })
-            this._background_process?.stdout?.on("data", (chunk) => {
-                data += chunk
-            })
-            this._background_process?.on("close", () => {
-                resolve(data)
-            })
-        })
 
-        const exit_code = this._background_process.exitCode
+            const exit_code = backgroundProcess.exitCode
 
-        this._background_process = undefined
-
-        Log.trace(
-            `Info process exited with code: ${exit_code}, information: ${info_string.trim()}`,
-            LOGLOC,
-        )
-
-        if (info_string === "") {
-            Log.error(
-                "Unable to connect to instrument, could not get instrument information",
+            Log.trace(
+                `Info process exited with code: ${exit_code}, information: ${info_string.trim()}`,
                 LOGLOC,
             )
-            return null
-        }
 
-        return <IIDNInfo>JSON.parse(info_string)
+            if (info_string === "") {
+                Log.error(
+                    "Unable to connect to instrument, could not get instrument information",
+                    LOGLOC,
+                )
+                return null
+            }
+
+            return <IIDNInfo>JSON.parse(info_string)
+        } finally {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle)
+            }
+
+            if (this._background_process === backgroundProcess) {
+                this._background_process = undefined
+            }
+        }
     }
 
     async dumpOutputQueue(): Promise<string | undefined> {
@@ -1044,14 +1127,17 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connection.dumpOutputQueue()",
         }
+
         let dump_path: string | undefined = undefined
+
         Log.info("Dumping data from instrument output queue", LOGLOC)
+
         const dump_dir = mkdtempSync(join(os.tmpdir(), "tsp-toolkit-"))
         dump_path = join(dump_dir, "dump-output")
 
         Log.trace(`Dumping data to ${dump_path}`, LOGLOC)
 
-        this._background_process = child.spawn(EXECUTABLE, [
+        const backgroundProcess = child.spawn(EXECUTABLE, [
             "--log-file",
             join(
                 LOG_DIR,
@@ -1063,16 +1149,23 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             dump_path,
         ])
 
+        this._background_process = backgroundProcess
+
         await new Promise<void>((resolve) => {
-            this._background_process?.on("close", () => {
+            backgroundProcess.on("close", () => {
                 Log.trace(
-                    `Dump process exited with code: ${this._background_process?.exitCode}`,
+                    `Dump process exited with code: ${backgroundProcess.exitCode}`,
                     LOGLOC,
                 )
-                this._background_process = undefined
+
+                if (this._background_process === backgroundProcess) {
+                    this._background_process = undefined
+                }
+
                 resolve()
             })
         })
+
         return dump_path
     }
 
@@ -1083,15 +1176,21 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             token: vscode.CancellationToken
         },
     ): Promise<boolean> {
-        const LOGLOC = { file: "instruments.ts", func: "Connection.connect()" }
+        const LOGLOC = {
+            file: "instruments.ts",
+            func: "Connection.connect()",
+        }
+
         const orig_status = this.status
         //this.status = ConnectionStatus.Connected
+
         if (this._parent) {
             this._parent.savingTspOutput = false
         }
 
         if (!this._terminal) {
             Log.debug("Creating terminal", LOGLOC)
+
             if (progressContext) {
                 return this.runConnectFlowWithTimeout(
                     name,
@@ -1117,11 +1216,12 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                         LOGLOC,
                     ),
             )
+
             return result ?? false
-        } else {
-            this.showTerminal()
-            return true
         }
+
+        this.showTerminal()
+        return true
     }
 
     showTerminal() {
@@ -1135,27 +1235,32 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connection.reset()",
         }
+
         if (this._terminal) {
             Log.debug("Terminal exists, sending .reset", LOGLOC)
             this.showTerminal()
-            this._terminal?.sendText(".reset")
+            this._terminal.sendText(".reset")
             return
         }
+
         if (this._background_process) {
             //wait for a background process slot to open up if it is busy
             Log.debug(
                 "Terminal doesn't exist and background process is busy. Waiting...",
                 LOGLOC,
             )
-            await new Promise<void>((r) =>
-                this._background_process?.on("close", () => r()),
+
+            await new Promise<void>((resolve) =>
+                this._background_process?.on("close", () => resolve()),
             )
+
             Log.debug(
                 "... Background process finished starting new reset call in background process",
                 LOGLOC,
             )
         }
-        this._background_process = child.spawn(EXECUTABLE, [
+
+        const backgroundProcess = child.spawn(EXECUTABLE, [
             "--log-file",
             join(
                 LOG_DIR,
@@ -1165,13 +1270,19 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             this.addr,
         ])
 
+        this._background_process = backgroundProcess
+
         await new Promise<void>((resolve) => {
-            this._background_process?.on("close", () => {
+            backgroundProcess.on("close", () => {
                 Log.trace(
-                    `Reset process exited with code: ${this._background_process?.exitCode}`,
+                    `Reset process exited with code: ${backgroundProcess.exitCode}`,
                     LOGLOC,
                 )
-                this._background_process = undefined
+
+                if (this._background_process === backgroundProcess) {
+                    this._background_process = undefined
+                }
+
                 resolve()
             })
         })
@@ -1182,27 +1293,32 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connection.abort()",
         }
+
         if (this._terminal) {
             Log.debug("Terminal exists, sending .abort", LOGLOC)
             this.showTerminal()
-            this._terminal?.sendText(".abort")
+            this._terminal.sendText(".abort")
             return
         }
+
         if (this._background_process) {
             //wait for a background process slot to open up if it is busy
             Log.debug(
                 "Terminal doesn't exist and background process is busy. Waiting...",
                 LOGLOC,
             )
-            await new Promise<void>((r) =>
-                this._background_process?.on("close", () => r()),
+
+            await new Promise<void>((resolve) =>
+                this._background_process?.on("close", () => resolve()),
             )
+
             Log.debug(
                 "... Background process finished starting new abort call in background process",
                 LOGLOC,
             )
         }
-        this._background_process = child.spawn(EXECUTABLE, [
+
+        const backgroundProcess = child.spawn(EXECUTABLE, [
             "--log-file",
             join(
                 LOG_DIR,
@@ -1213,13 +1329,19 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             this.addr,
         ])
 
+        this._background_process = backgroundProcess
+
         await new Promise<void>((resolve) => {
-            this._background_process?.on("close", () => {
+            backgroundProcess.on("close", () => {
                 Log.trace(
-                    `Abort process exited with code: ${this._background_process?.exitCode}`,
+                    `Abort process exited with code: ${backgroundProcess.exitCode}`,
                     LOGLOC,
                 )
-                this._background_process = undefined
+
+                if (this._background_process === backgroundProcess) {
+                    this._background_process = undefined
+                }
+
                 resolve()
             })
         })
@@ -1233,7 +1355,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
      *
      * **Note:** This could be done using the `kic update` subcommand in the future. This method
      * was chosen to maintain any possible visual loading bars that may eventually be
-     * printed to the terminal
+     * printed to the terminal.
      *
      * @param filepath The path to the update file
      * @param slot (optional) The slot of the mainframe to update
@@ -1243,12 +1365,15 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connection.update()",
         }
+
         if (!this._terminal) {
             await this.connect()
         }
+
         Log.debug("Terminal exists, sending .update", LOGLOC)
 
         const fileSize = statSync(filepath).size
+
         if (fileSize === 0) {
             vscode.window.showErrorMessage("Firmware file is empty (0 bytes)")
             return
@@ -1257,10 +1382,10 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         vscode.window.showInformationMessage(
             `Starting update on ${this._parent?.name}@${this._addr}${slot ? `, slot ${slot}` : ""}`,
         )
+
         this._terminal?.sendText(
             `.update ${slot ? `--slot ${slot}` : ""} "${filepath}"`,
         )
-        return
     }
 
     async startTspOutputSaving(output: string) {
@@ -1268,13 +1393,16 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connections.startTspOutputSaving()",
         }
+
         if (!this._terminal) {
             await this.connect()
         }
+
         Log.debug(
             `Terminal exists, sending .save --tsp --output ${output}`,
             LOGLOC,
         )
+
         this._terminal?.sendText(`.save --tsp --output "${output}"`)
     }
 
@@ -1283,11 +1411,13 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connections.stopTspOutputSaving()",
         }
+
         if (!this._terminal) {
             return
         }
+
         Log.debug("Terminal exists, sending .save --end", LOGLOC)
-        this._terminal?.sendText(".save --end")
+        this._terminal.sendText(".save --end")
     }
 
     async saveBufferContents(
@@ -1300,11 +1430,13 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connections.saveBufferContents()",
         }
+
         if (!this._terminal) {
             await this.connect()
         }
 
         const command = `.save --buffer "${buffers.join('" --buffer "')}" --format "${fields.join(",")}" --delimiter "${delimiter}" --output "${output}"`
+
         Log.debug(`Terminal exists, sending ${command}`, LOGLOC)
 
         this._terminal?.sendText(command)
@@ -1315,9 +1447,11 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             file: "instruments.ts",
             func: "Connections.stopTspOutputSaving()",
         }
+
         if (!this._terminal) {
             await this.connect()
         }
+
         Log.debug(
             `Terminal exists, sending .save --script ${script} --output ${output}`,
             LOGLOC,
@@ -1331,13 +1465,14 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
     sendScript(filepath: string) {
         if (this._terminal) {
             this.showTerminal()
-            this._terminal?.sendText(`.script "${filepath}"`)
+            this._terminal.sendText(`.script "${filepath}"`)
         }
     }
 
     async exitConnection() {
         if (this._terminal) {
-            this._terminal?.sendText(".exit")
+            this._terminal.sendText(".exit")
+
             await new Promise<void>((resolve) => {
                 const checkTerminal = setInterval(() => {
                     if (this._terminal === undefined) {
@@ -1352,7 +1487,8 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
     getNodes(filepath: string) {
         if (this._terminal) {
             this.showTerminal()
-            this._terminal?.sendText(
+
+            this._terminal.sendText(
                 `.nodes "${join(filepath, ".vscode/settings.json")}"`,
             )
         }
@@ -1366,12 +1502,19 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
     //    this._terminal?.sendText(".abort")
     //}
 
+    /**
+     * Update the connection status by checking whether the instrument is
+     * still reachable.
+     */
     async getUpdatedStatus(): Promise<void> {
         const info = await this.ping(1000)
+
         let new_status = ConnectionStatus.Inactive
+
         if (info?.serial_number === this._parent?.info.serial_number) {
             new_status = ConnectionStatus.Active
         }
+
         if (this.status !== new_status) {
             this.status = new_status
             this._onChangedStatus.fire(this.status)

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -376,8 +376,8 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
 
             vscode.window.showWarningMessage(
                 `Connecting to ${this.addr} timed out after ${timeoutSeconds} second(s). ` +
-                        "Check that the instrument is reachable, or increase the " +
-                        '"tsp.connectionTimeout" setting, and try again.',
+                    "Check that the instrument is reachable, or increase the " +
+                    '"tsp.connectionTimeout" setting, and try again.',
             )
 
             timeoutSource.cancel()

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -46,6 +46,11 @@ export type LoginStatus =
     | { type: "NotPrompted" }
     | { type: "InUse" }
 
+/**
+ * Identifies who/what triggered a connection attempt's cancellation.
+ */
+type CancelReason = "user" | "timeout"
+
 export function connectionStatusIcon(
     status: ConnectionStatus | undefined,
 ): vscode.ThemeIcon {
@@ -330,10 +335,26 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                 cancel,
                 orig_status,
                 LOGLOC,
+                () => "user",
             )
         }
 
         const timeoutSource = new vscode.CancellationTokenSource()
+
+        // Records which of the two tokens actually caused the cancellation, so
+        // runConnectFlow can report the real reason instead of guessing.
+        // Left undefined until the first of the two sources fires — whichever
+        // sets it first wins, so a near-simultaneous user-cancel/timeout race
+        // can't produce an ambiguous reason.
+        let cancelReason: CancelReason | undefined
+
+        // Registered before combineCancellationTokens() so it always runs
+        // before the forwarding listener that triggers runConnectFlow's
+        // cancellation handler — otherwise getCancelReason() could be read
+        // before "user" is recorded.
+        const userCancellationListener = cancel.onCancellationRequested(() => {
+            cancelReason ??= "user"
+        })
 
         const combined = Connection.combineCancellationTokens(
             cancel,
@@ -341,10 +362,12 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         )
 
         const timeoutHandle = setTimeout(() => {
-            // If the user already cancelled, don't report a timeout.
-            if (cancel.isCancellationRequested) {
+            // Someone else (the user) already claimed the cancellation.
+            if (cancelReason !== undefined) {
                 return
             }
+
+            cancelReason = "timeout"
 
             Log.warn(
                 `Connection to ${this.addr} timed out after ${timeoutSeconds} second(s)`,
@@ -352,7 +375,9 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             )
 
             vscode.window.showWarningMessage(
-                `Connecting to ${this.addr} timed out after ${timeoutSeconds} second(s). The connection attempt has been cancelled.`,
+                `Connecting to ${this.addr} timed out after ${timeoutSeconds} second(s). ` +
+                        "Check that the instrument is reachable, or increase the " +
+                        '"tsp.connectionTimeout" setting, and try again.',
             )
 
             timeoutSource.cancel()
@@ -365,10 +390,13 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                 combined.token,
                 orig_status,
                 LOGLOC,
+                () => cancelReason ?? "user",
             )
         } finally {
             clearTimeout(timeoutHandle)
+            userCancellationListener.dispose()
             combined.dispose()
+            timeoutSource.dispose()
         }
     }
 
@@ -378,6 +406,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         cancel: vscode.CancellationToken,
         orig_status: ConnectionStatus | undefined,
         LOGLOC: { file: string; func: string },
+        getCancelReason: () => CancelReason,
     ): Promise<boolean> {
         const cancelIfRequested = (): boolean => {
             if (!cancel.isCancellationRequested) {
@@ -398,7 +427,14 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         // Disposed in the finally block below so this listener doesn't
         // outlive a single connect() attempt
         const cancellationListener = cancel.onCancellationRequested(() => {
-            Log.info("Connection attempt cancelled", LOGLOC)
+            const reason = getCancelReason()
+
+            if (reason === "timeout") {
+                Log.warn("Connection attempt cancelled due to timeout", LOGLOC)
+            } else {
+                Log.info("Connection attempt cancelled by user", LOGLOC)
+            }
+
             this.terminateBackgroundProcessOnCancel()
             this.status = orig_status
         })

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -220,6 +220,28 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         return this._terminal
     }
 
+    /**
+     * Combine multiple cancellation tokens into a single token.
+     *
+     * The returned token is cancelled as soon as any one of the input tokens
+     * is cancelled.
+     */
+    private static combineCancellationTokens(
+        ...tokens: vscode.CancellationToken[]
+    ): vscode.CancellationToken {
+        const combinedSource = new vscode.CancellationTokenSource()
+
+        for (const token of tokens) {
+            if (token.isCancellationRequested) {
+                combinedSource.cancel()
+            }
+
+            token.onCancellationRequested(() => combinedSource.cancel())
+        }
+
+        return combinedSource.token
+    }
+
     private terminateBackgroundProcessOnCancel() {
         if (!this._background_process) {
             return
@@ -237,6 +259,78 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         }
 
         this._background_process = undefined
+    }
+
+    /**
+     * Wraps runConnectFlow with a user-configurable connection timeout.
+     *
+     * Cancellation can happen from either:
+     * - the user cancelling the VS Code progress notification, or
+     * - the configured connection timeout expiring.
+     *
+     * Both paths use the same cancellation handling inside runConnectFlow,
+     * which terminates the active background process and restores the
+     * original connection status.
+     */
+    private async runConnectFlowWithTimeout(
+        name: string | undefined,
+        progress: vscode.Progress<{ message?: string; increment?: number }>,
+        cancel: vscode.CancellationToken,
+        orig_status: ConnectionStatus | undefined,
+        LOGLOC: { file: string; func: string },
+    ): Promise<boolean> {
+        const timeoutSeconds = vscode.workspace
+            .getConfiguration("tsp")
+            .get<number>("connectionTimeout", 30)
+
+        // A timeout of 0 (or an invalid value) disables the timeout entirely
+        if (!timeoutSeconds || timeoutSeconds <= 0) {
+            return this.runConnectFlow(
+                name,
+                progress,
+                cancel,
+                orig_status,
+                LOGLOC,
+            )
+        }
+
+        const timeoutSource = new vscode.CancellationTokenSource()
+
+        const timeoutHandle = setTimeout(() => {
+            // If the user already cancelled, don't report a timeout.
+            if (cancel.isCancellationRequested) {
+                return
+            }
+
+            Log.warn(
+                `Connection to ${this.addr} timed out after ${timeoutSeconds} second(s)`,
+                LOGLOC,
+            )
+
+            vscode.window.showWarningMessage(
+                `Connecting to ${this.addr} timed out after ${timeoutSeconds} second(s). The connection attempt has been cancelled.`,
+            )
+
+            timeoutSource.cancel()
+        }, timeoutSeconds * 1000)
+
+        const combinedToken = Connection.combineCancellationTokens(
+            cancel,
+            timeoutSource.token,
+        )
+
+        try {
+            return await this.runConnectFlow(
+                name,
+                progress,
+                combinedToken,
+                orig_status,
+                LOGLOC,
+            )
+        } finally {
+            clearTimeout(timeoutHandle)
+            timeoutSource.dispose()
+        }
     }
 
     private async runConnectFlow(
@@ -409,7 +503,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         } else {
             this._parent.updateInfo(info)
         }
-        
+
         // check before persistence to avoid saving cancelled connection attempts
         if (cancelIfRequested()) {
             return false
@@ -999,7 +1093,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         if (!this._terminal) {
             Log.debug("Creating terminal", LOGLOC)
             if (progressContext) {
-                return this.runConnectFlow(
+                return this.runConnectFlowWithTimeout(
                     name,
                     progressContext.progress,
                     progressContext.token,
@@ -1015,7 +1109,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                     title: `Connecting to ${this.addr}`,
                 },
                 async (progress, cancel) =>
-                    this.runConnectFlow(
+                    this.runConnectFlowWithTimeout(
                         name,
                         progress,
                         cancel,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -395,294 +395,313 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         // temporary added delay for testing
         //await new Promise((resolve) => setTimeout(resolve, 3000))
 
-        cancel.onCancellationRequested(() => {
+        // Disposed in the finally block below so this listener doesn't
+        // outlive a single connect() attempt
+        const cancellationListener = cancel.onCancellationRequested(() => {
             Log.info("Connection attempt cancelled", LOGLOC)
             this.terminateBackgroundProcessOnCancel()
             this.status = orig_status
         })
 
-        if (cancelIfRequested()) {
-            return false
-        }
-        //Dump output queue if enabled
-        // Disabled dumping output queue on connect until it is reimplemented
-        //let dump_path = undefined
-        //if (
-        //    vscode.workspace
-        //        .getConfiguration("tsp")
-        //        .get("dumpQueueOnConnect") === true
-        //) {
-        //    progress.report({
-        //        message:
-        //            "Dumping data from instrument output queue",
-        //    })
-        //    dump_path = await this.dumpOutputQueue()
-        //}
-
-        progress.report({
-            message: "Checking if instrument requires authentication",
-        })
-
-        if (cancelIfRequested()) {
-            return false
-        }
-
-        const login_required = await this.checkLogin()
-
-        // check after await: cancellation might occur while checkLogin is running
-        if (cancelIfRequested()) {
-            return false
-        }
-
-        if (login_required.type === "NotPrompted") {
-            Log.debug("No login required", LOGLOC)
-        } else if (login_required.type === "InUse") {
-            vscode.window.showErrorMessage(
-                `Instrument at ${this._addr} already in use. Make sure you logout at other locations before connecting.`,
-            )
-            Log.error("Connection failed: instrument already in use.", LOGLOC)
-            this.status = orig_status
-            return false
-        } else if (login_required.type === "Protected") {
-            for (let i = 1; i <= 3; i++) {
-                //TODO: Prompt for the required information (if any)
-                if (i > 1 && login_required.keyring) {
-                    login_required.keyring = undefined
-                }
-
-                progress.report({
-                    message: `Attempt ${i} of 3: Prompting for instrument authentication details`,
-                })
-
-                // check before prompt: avoid opening/continuing interactive UI after cancel
-                if (cancelIfRequested()) {
-                    return false
-                }
-
-                const login_details = await this.promptDetails(login_required)
-
-                // check after await: user may cancel while input box is open
-                if (cancelIfRequested()) {
-                    return false
-                }
-
-                this._keyring = await this.login(login_details)
-
-                // check after await: login process may still complete after cancellation
-                if (cancelIfRequested()) {
-                    return false
-                }
-
-                if (this._keyring) {
-                    break
-                }
-
-                if (
-                    (this._keyring === undefined || this._keyring === null) &&
-                    i < 3
-                ) {
-                    vscode.window.showWarningMessage(
-                        `Credentials incorrect for instrument at ${this._addr}, please try again.`,
-                    )
-                    Log.error(
-                        "Credentials are incorrect, please try again.",
-                        LOGLOC,
-                    )
-                }
-
-                if (
-                    (this._keyring === undefined || this._keyring === null) &&
-                    i === 3
-                ) {
-                    vscode.window.showErrorMessage(
-                        `Unable to connect to instrument at ${this._addr}, please check your credentials and try again.`,
-                    )
-                    Log.error(
-                        "Connection failed: unable to reach requested instrument, user exceeded login attempts.",
-                        LOGLOC,
-                    )
-                    this.status = orig_status
-                    return false
-                }
+        try {
+            if (cancelIfRequested()) {
+                return false
             }
-        } else {
-            vscode.window.showErrorMessage(
-                `Unable to connect to instrument at ${this._addr}`,
-            )
-            Log.error(
-                "Connection failed: unable to reach requested instrument.",
-                LOGLOC,
-            )
-            this.status = orig_status
-            return false
-        }
+            //Dump output queue if enabled
+            // Disabled dumping output queue on connect until it is reimplemented
+            //let dump_path = undefined
+            //if (
+            //    vscode.workspace
+            //        .getConfiguration("tsp")
+            //        .get("dumpQueueOnConnect") === true
+            //) {
+            //    progress.report({
+            //        message:
+            //            "Dumping data from instrument output queue",
+            //    })
+            //    dump_path = await this.dumpOutputQueue()
+            //}
 
-        //Get instrument info
-        progress.report({
-            message: "Getting instrument information",
-        })
+            progress.report({
+                message: "Checking if instrument requires authentication",
+            })
 
-        if (cancelIfRequested()) {
-            return false
-        }
+            if (cancelIfRequested()) {
+                return false
+            }
 
-        const info = await this.ping()
+            const login_required = await this.checkLogin()
 
-        // check after await: ping can return after cancellation was requested
-        if (cancelIfRequested()) {
-            return false
-        }
+            // check after await: cancellation might occur while checkLogin is running
+            if (cancelIfRequested()) {
+                return false
+            }
 
-        if (!info) {
-            vscode.window.showErrorMessage(
-                `Unable to connect to instrument at ${this.addr}: could not get instrument information`,
-            )
-            this.status = orig_status
-            return false
-        }
+            if (login_required.type === "NotPrompted") {
+                Log.debug("No login required", LOGLOC)
+            } else if (login_required.type === "InUse") {
+                vscode.window.showErrorMessage(
+                    `Instrument at ${this._addr} already in use. Make sure you logout at other locations before connecting.`,
+                )
+                Log.error(
+                    "Connection failed: instrument already in use.",
+                    LOGLOC,
+                )
+                this.status = orig_status
+                return false
+            } else if (login_required.type === "Protected") {
+                for (let i = 1; i <= 3; i++) {
+                    //TODO: Prompt for the required information (if any)
+                    if (i > 1 && login_required.keyring) {
+                        login_required.keyring = undefined
+                    }
 
-        if (!this._parent) {
-            this._parent = new Instrument(info, name !== "" ? name : undefined)
-            this._parent.addConnection(this)
-        } else {
-            this._parent.updateInfo(info)
-        }
+                    progress.report({
+                        message: `Attempt ${i} of 3: Prompting for instrument authentication details`,
+                    })
 
-        // check before persistence to avoid saving cancelled connection attempts
-        if (cancelIfRequested()) {
-            return false
-        }
+                    // check before prompt: avoid opening/continuing interactive UI after cancel
+                    if (cancelIfRequested()) {
+                        return false
+                    }
 
-        InstrumentProvider.instance.addOrUpdateInstrument(this._parent)
-        await InstrumentProvider.instance.saveInstrument(this._parent)
+                    const login_details =
+                        await this.promptDetails(login_required)
 
-        // check after await: save operation may complete after cancellation
-        if (cancelIfRequested()) {
-            return false
-        }
+                    // check after await: user may cancel while input box is open
+                    if (cancelIfRequested()) {
+                        return false
+                    }
 
-        const additional_terminal_args: string[] = []
+                    this._keyring = await this.login(login_details)
 
-        // Disabled dumping output queue on connect until it is reimplemented
-        //if (dump_path) {
-        //    additional_terminal_args.push(
-        //        "--dump-output",
-        //        dump_path,
-        //    )
-        //}
+                    // check after await: login process may still complete after cancellation
+                    if (cancelIfRequested()) {
+                        return false
+                    }
 
-        progress.report({
-            message: `Connecting to instrument with model ${info.model} and S/N ${info.serial_number}`,
-        })
+                    if (this._keyring) {
+                        break
+                    }
 
-        //Connect terminal
-        if (cancelIfRequested()) {
-            return false
-        }
+                    if (
+                        (this._keyring === undefined ||
+                            this._keyring === null) &&
+                        i < 3
+                    ) {
+                        vscode.window.showWarningMessage(
+                            `Credentials incorrect for instrument at ${this._addr}, please try again.`,
+                        )
+                        Log.error(
+                            "Credentials are incorrect, please try again.",
+                            LOGLOC,
+                        )
+                    }
 
-        const terminal_args = [
-            "--log-file",
-            join(
-                LOG_DIR,
-                `${new Date().toISOString().substring(0, 10)}-kic.log`,
-            ),
-            "connect",
-            this.addr,
-        ]
+                    if (
+                        (this._keyring === undefined ||
+                            this._keyring === null) &&
+                        i === 3
+                    ) {
+                        vscode.window.showErrorMessage(
+                            `Unable to connect to instrument at ${this._addr}, please check your credentials and try again.`,
+                        )
+                        Log.error(
+                            "Connection failed: unable to reach requested instrument, user exceeded login attempts.",
+                            LOGLOC,
+                        )
+                        this.status = orig_status
+                        return false
+                    }
+                }
+            } else {
+                vscode.window.showErrorMessage(
+                    `Unable to connect to instrument at ${this._addr}`,
+                )
+                Log.error(
+                    "Connection failed: unable to reach requested instrument.",
+                    LOGLOC,
+                )
+                this.status = orig_status
+                return false
+            }
 
-        for (const a of additional_terminal_args) {
-            terminal_args.push(a)
-        }
+            //Get instrument info
+            progress.report({
+                message: "Getting instrument information",
+            })
 
-        if (this._keyring) {
-            terminal_args.push("--keyring", this._keyring)
-        }
+            if (cancelIfRequested()) {
+                return false
+            }
 
-        if (vscode.workspace.getConfiguration("tsp").get("reset") === true) {
-            terminal_args.push("--reset")
-        }
+            const info = await this.ping()
 
-        if (
-            vscode.workspace.getConfiguration("tsp").get("clearErrorQueue") ===
-            true
-        ) {
-            terminal_args.push("--clear-error-queue")
-        }
+            // check after await: ping can return after cancellation was requested
+            if (cancelIfRequested()) {
+                return false
+            }
 
-        Log.debug("Starting VSCode Terminal", LOGLOC)
+            if (!info) {
+                vscode.window.showErrorMessage(
+                    `Unable to connect to instrument at ${this.addr}: could not get instrument information`,
+                )
+                this.status = orig_status
+                return false
+            }
 
-        this._terminal = vscode.window.createTerminal({
-            name: this._parent.name,
-            shellPath: EXECUTABLE,
-            shellArgs: terminal_args,
-            isTransient: true, // Don't try to reinitialize the terminal when restarting vscode
-            iconPath: {
-                light: vscode.Uri.file(
-                    join(
-                        __dirname,
-                        "..",
-                        "resources",
-                        "light",
-                        "tsp-terminal-icon.svg",
-                    ),
+            if (!this._parent) {
+                this._parent = new Instrument(
+                    info,
+                    name !== "" ? name : undefined,
+                )
+                this._parent.addConnection(this)
+            } else {
+                this._parent.updateInfo(info)
+            }
+
+            // check before persistence to avoid saving cancelled connection attempts
+            if (cancelIfRequested()) {
+                return false
+            }
+
+            InstrumentProvider.instance.addOrUpdateInstrument(this._parent)
+            await InstrumentProvider.instance.saveInstrument(this._parent)
+
+            // check after await: save operation may complete after cancellation
+            if (cancelIfRequested()) {
+                return false
+            }
+
+            const additional_terminal_args: string[] = []
+
+            // Disabled dumping output queue on connect until it is reimplemented
+            //if (dump_path) {
+            //    additional_terminal_args.push(
+            //        "--dump-output",
+            //        dump_path,
+            //    )
+            //}
+
+            progress.report({
+                message: `Connecting to instrument with model ${info.model} and S/N ${info.serial_number}`,
+            })
+
+            //Connect terminal
+            if (cancelIfRequested()) {
+                return false
+            }
+
+            const terminal_args = [
+                "--log-file",
+                join(
+                    LOG_DIR,
+                    `${new Date().toISOString().substring(0, 10)}-kic.log`,
                 ),
-                dark: vscode.Uri.file(
-                    join(
-                        __dirname,
-                        "..",
-                        "resources",
-                        "dark",
-                        "tsp-terminal-icon.svg",
-                    ),
-                ),
-            },
-        })
+                "connect",
+                this.addr,
+            ]
 
-        this._terminal.show(false)
+            for (const a of additional_terminal_args) {
+                terminal_args.push(a)
+            }
 
-        // Handle cancellation after terminal is created
-        if (cancelIfRequested()) {
-            this._terminal.dispose()
-            this._terminal = undefined
-            return false
-        }
-
-        this.status = ConnectionStatus.Connected
-
-        vscode.window.onDidCloseTerminal((t) => {
-            Log.info("Terminal closed", LOGLOC)
+            if (this._keyring) {
+                terminal_args.push("--keyring", this._keyring)
+            }
 
             if (
-                t.creationOptions.iconPath !== undefined &&
-                // eslint-disable-next-line @typescript-eslint/no-base-to-string
-                t.creationOptions.iconPath
-                    .toString()
-                    .search("tsp-terminal-icon") &&
-                t.name === this._parent?.name &&
-                t.processId === this._terminal?.processId
+                vscode.workspace.getConfiguration("tsp").get("reset") === true
             ) {
-                this.status = ConnectionStatus.Active
+                terminal_args.push("--reset")
+            }
+
+            if (
+                vscode.workspace
+                    .getConfiguration("tsp")
+                    .get("clearErrorQueue") === true
+            ) {
+                terminal_args.push("--clear-error-queue")
+            }
+
+            Log.debug("Starting VSCode Terminal", LOGLOC)
+
+            this._terminal = vscode.window.createTerminal({
+                name: this._parent.name,
+                shellPath: EXECUTABLE,
+                shellArgs: terminal_args,
+                isTransient: true, // Don't try to reinitialize the terminal when restarting vscode
+                iconPath: {
+                    light: vscode.Uri.file(
+                        join(
+                            __dirname,
+                            "..",
+                            "resources",
+                            "light",
+                            "tsp-terminal-icon.svg",
+                        ),
+                    ),
+                    dark: vscode.Uri.file(
+                        join(
+                            __dirname,
+                            "..",
+                            "resources",
+                            "dark",
+                            "tsp-terminal-icon.svg",
+                        ),
+                    ),
+                },
+            })
+
+            this._terminal.show(false)
+
+            // Handle cancellation after terminal is created
+            if (cancelIfRequested()) {
+                this._terminal.dispose()
                 this._terminal = undefined
+                return false
+            }
+
+            this.status = ConnectionStatus.Connected
+
+            vscode.window.onDidCloseTerminal((t) => {
+                Log.info("Terminal closed", LOGLOC)
 
                 if (
-                    t.exitStatus?.reason !== vscode.TerminalExitReason.Process
+                    t.creationOptions.iconPath !== undefined &&
+                    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+                    t.creationOptions.iconPath
+                        .toString()
+                        .search("tsp-terminal-icon") &&
+                    t.name === this._parent?.name &&
+                    t.processId === this._terminal?.processId
                 ) {
-                    setTimeout(() => {
-                        Log.debug("Resetting closed instrument", LOGLOC)
-                        this.reset().catch(() => {})
-                        this.status = ConnectionStatus.Active
-                    }, 500)
+                    this.status = ConnectionStatus.Active
+                    this._terminal = undefined
+
+                    if (
+                        t.exitStatus?.reason !==
+                        vscode.TerminalExitReason.Process
+                    ) {
+                        setTimeout(() => {
+                            Log.debug("Resetting closed instrument", LOGLOC)
+                            this.reset().catch(() => {})
+                            this.status = ConnectionStatus.Active
+                        }, 500)
+                    }
                 }
-            }
-        }, this)
+            }, this)
 
-        Log.debug(`Connected to ${this._parent.name}`, LOGLOC)
+            Log.debug(`Connected to ${this._parent.name}`, LOGLOC)
 
-        progress.report({
-            message: `Connected to instrument with model ${info.model} and S/N ${info.serial_number}, saving to global settings`,
-        })
+            progress.report({
+                message: `Connected to instrument with model ${info.model} and S/N ${info.serial_number}, saving to global settings`,
+            })
 
-        return true
+            return true
+        } finally {
+            cancellationListener.dispose()
+        }
     }
 
     async checkLogin(timeout_ms?: number): Promise<LoginStatus> {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -466,6 +466,21 @@ export class Instrument extends vscode.TreeItem implements vscode.Disposable {
                 ) {
                     this._connections[sameTypeIdx].status = connection.status
                 }
+
+                // Keep forwarding status as `connection` changes later (e.g.
+                // Connecting -> Connected -> Active); otherwise the tracked
+                // connection's icon freezes at whatever status it had here.
+                connection.onChangedStatus(() => {
+                    if (
+                        connection.status !== undefined &&
+                        this._connections[sameTypeIdx].status !==
+                            connection.status
+                    ) {
+                        this._connections[sameTypeIdx].status =
+                            connection.status
+                    }
+                }, this)
+
                 return false
             } else {
                 // Address changed: remove the old connection


### PR DESCRIPTION
Users can now set connectionTimeout to bound how long a connection attempt may run. If it doesn't complete in time, the attempt is cancelled and the user is notified with a warning message.

- Added a new setting tsp.connectionTimeout (number, seconds, default 30, 0 disables it) so users can configure how long a connection attempt may run before being aborted.
- Added Connection.combineCancellationTokens(), a helper that merges multiple vscode.CancellationTokens into one that fires when any of them cancels. This lets the timeout and the user's manual "Cancel" click in the progress notification share the same cancellation path already used inside runConnectFlow.
- Added runConnectFlowWithTimeout(), which:
Reads tsp.connectionTimeout from configuration.
If 0/invalid, calls runConnectFlow unchanged (no timeout).
Otherwise starts a setTimeout for that many seconds; if it fires, logs a warning, and shows warning message to notify the user the connection timed out.