### PR TITLE
Add autorefresh, automatically cull stale instrument connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Rename 'Upgrade firmware' to 'Update firmware'.
 - Update instrument explorer as new discovered instruments come in rather than after discovery completes
 - **tsp-toolkit-kic-cli** - Run discovery for lan and visa in parallel
+
 ### Added
 - TSP language interop feature.
+- Continuously discover instruments by default (disable by setting the `tsp.autorefresh` setting to `false`)
 - **tsp-toolkit-language-interop** - Implement tsp language interop feature
 
 

--- a/package.json
+++ b/package.json
@@ -479,6 +479,12 @@
                     "default": false,
                     "scope": "application",
                     "description": "Ignore the VISA installation check notification. VISA is optional and only required for VISA protocol instrument communication."
+                },
+                "tsp.autorefresh": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope":"resource",
+                    "description": "Enable (true) or disable (false) the auto-refresh of the instrument explorer"
                 }
             }
         },
@@ -517,7 +523,7 @@
             "view/title": [
                 {
                     "command": "InstrumentsExplorer.refresh",
-                    "when": "view == InstrumentsExplorer",
+                    "when": "view == InstrumentsExplorer && config.tsp.autorefresh == false",
                     "group": "navigation"
                 },
                 {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -202,6 +202,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
 
         if (this._status !== status) {
             this._status = status
+            console.error(`[${this._addr}]: status = ${status}`)
             this._onChangedStatus.fire(this._status)
         }
     }
@@ -219,6 +220,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
     }
 
     set foundLastRound(a: boolean) {
+        console.error(`[${this.addr}: foundLastRound = ${a}]`)
         this._foundLastRound = a
     }
     get foundLastRound(): boolean {
@@ -1573,6 +1575,11 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
     async getUpdatedStatus(): Promise<void> {
         const info = await this.ping(1000)
 
+        if (this.foundLastRound) {
+            this.status = ConnectionStatus.Active
+            return
+        }
+
         let new_status = ConnectionStatus.Inactive
 
         if (info?.serial_number === this._parent?.info.serial_number) {
@@ -1580,7 +1587,9 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         }
 
         if (this.status !== new_status) {
+            console.error("getUpdatedStatus: Updating status")
             this.status = new_status
+            this.foundLastRound = true
             this._onChangedStatus.fire(this.status)
         }
     }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -98,6 +98,7 @@ export function contextValueStatus(
  * A tree item that holds the details of an instrument connection interface/protocol
  */
 export class Connection extends vscode.TreeItem implements vscode.Disposable {
+    private _foundLastRound = true
     private _type: IoType = IoType.Lan
     private _addr: string = ""
     private _keyring: string | null | undefined = undefined
@@ -125,6 +126,7 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
         this._addr = addr
         this.contextValue = "CONN"
         this.status = ConnectionStatus.Inactive
+        this._foundLastRound = true
         this.enable(true)
     }
     dispose() {
@@ -207,6 +209,13 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
 
     get terminal() {
         return this._terminal
+    }
+
+    set foundLastRound(a: boolean) {
+        this._foundLastRound = a
+    }
+    get foundLastRound(): boolean {
+        return this._foundLastRound
     }
 
     async checkLogin(timeout_ms?: number): Promise<LoginStatus> {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -446,6 +446,7 @@ export class Instrument extends vscode.TreeItem implements vscode.Disposable {
         if (sameTypeIdx > -1) {
             // If the address is the same, just update status if needed
             if (this._connections[sameTypeIdx].addr === connection.addr) {
+                this._connections[sameTypeIdx].foundLastRound = true
                 if (
                     connection.status !== undefined &&
                     this._connections[sameTypeIdx].status !== connection.status

--- a/src/instrumentExplorer.ts
+++ b/src/instrumentExplorer.ts
@@ -100,17 +100,29 @@ export class InstrumentsExplorer implements vscode.Disposable {
             StatusType.Progress,
         )
 
-        this.treeDataProvider
-            ?.refresh(async () => await this.startDiscovery())
-            .then(
-                () => {
-                    StatusBarManager.instance.hide()
-                },
-                (e: Error) => {
-                    StatusBarManager.instance.hide()
-                    Log.error(`Unable to start Discovery ${e.message}`, LOGLOC)
-                },
-            )
+        const interval = setInterval(() => {
+            this.treeDataProvider
+                ?.refresh(async () => await this.startDiscovery())
+                .then(
+                    () => {
+                        StatusBarManager.instance.hide()
+                        if (
+                            !(vscode.workspace
+                                .getConfiguration("tsp")
+                                .get("autorefresh") as boolean)
+                        ) {
+                            clearInterval(interval)
+                        }
+                    },
+                    (e: Error) => {
+                        StatusBarManager.instance.hide()
+                        Log.error(
+                            `Unable to start Discovery ${e.message}`,
+                            LOGLOC,
+                        )
+                    },
+                )
+        }, 5000)
     }
     dispose() {
         this.treeDataProvider?.dispose()

--- a/src/instrumentExplorer.ts
+++ b/src/instrumentExplorer.ts
@@ -9,7 +9,6 @@ import { DISCOVER_EXECUTABLE } from "./kic-cli"
 import { LOG_DIR } from "./utility"
 import { ConnectionHelper } from "./resourceManager"
 import { StatusBarManager, StatusType } from "./statusBarManager"
-import { start } from "repl"
 
 const DISCOVERY_TIMEOUT = 4
 

--- a/src/instrumentExplorer.ts
+++ b/src/instrumentExplorer.ts
@@ -9,15 +9,16 @@ import { DISCOVER_EXECUTABLE } from "./kic-cli"
 import { LOG_DIR } from "./utility"
 import { ConnectionHelper } from "./resourceManager"
 import { StatusBarManager, StatusType } from "./statusBarManager"
+import { start } from "repl"
 
-const DISCOVERY_TIMEOUT = 5
+const DISCOVERY_TIMEOUT = 4
 
 export class InstrumentsExplorer implements vscode.Disposable {
     private InstrumentsDiscoveryViewer: vscode.TreeView<
         Instrument | Connection | InactiveInstrumentList
     >
     private treeDataProvider?: InstrumentProvider
-    private intervalID?: NodeJS.Timeout
+    private timeoutID?: NodeJS.Timeout
     //private _kicProcessMgr: KicProcessMgr
     private _discoveryInProgress: boolean = false
 
@@ -100,18 +101,19 @@ export class InstrumentsExplorer implements vscode.Disposable {
             StatusType.Progress,
         )
 
-        const interval = setInterval(() => {
+        const start_discovery = () => {
             this.treeDataProvider
                 ?.refresh(async () => await this.startDiscovery())
                 .then(
                     () => {
+                        this.timeoutID = undefined
                         StatusBarManager.instance.hide()
                         if (
-                            !(vscode.workspace
+                            vscode.workspace
                                 .getConfiguration("tsp")
-                                .get("autorefresh") as boolean)
+                                .get("autorefresh") as boolean
                         ) {
-                            clearInterval(interval)
+                            this.timeoutID = setTimeout(start_discovery, 5000)
                         }
                     },
                     (e: Error) => {
@@ -122,7 +124,35 @@ export class InstrumentsExplorer implements vscode.Disposable {
                         )
                     },
                 )
-        }, 5000)
+        }
+        if (
+            vscode.workspace
+                .getConfiguration("tsp")
+                .get("autorefresh") as boolean
+        ) {
+            start_discovery()
+        }
+
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration("tsp.autorefresh")) {
+                if (
+                    !(vscode.workspace
+                        .getConfiguration("tsp")
+                        .get("autorefresh") as boolean) &&
+                    this.timeoutID
+                ) {
+                    clearTimeout(this.timeoutID)
+                    this.timeoutID = undefined
+                } else if (
+                    (vscode.workspace
+                        .getConfiguration("tsp")
+                        .get("autorefresh") as boolean) &&
+                    !this.timeoutID
+                ) {
+                    start_discovery()
+                }
+            }
+        })
     }
     dispose() {
         this.treeDataProvider?.dispose()
@@ -161,7 +191,6 @@ export class InstrumentsExplorer implements vscode.Disposable {
 
                 discover.on("exit", () => {
                     StatusBarManager.instance.hide()
-                    clearInterval(this.intervalID)
                     this._discoveryInProgress = false
                     resolve()
                 })

--- a/src/instrumentProvider.ts
+++ b/src/instrumentProvider.ts
@@ -255,6 +255,7 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
         //     file: "instruments.ts",
         //     func: `InstrumentTreeDataProvider.addOrUpdateInstrument()`,
         // }
+        console.error("addOrUpdateInstrument start")
 
         const found_idx = this._instruments.findIndex(
             (v) =>
@@ -291,6 +292,7 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
             this._instruments.push(instrument)
             changed = true
         }
+        console.error("addOrUpdateInstrument end")
 
         this.reloadTreeData()
     }
@@ -511,6 +513,7 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
                         this._instruments.find(
                             (i) => i.info.serial_number === v.serial_number,
                         ) ?? Instrument.from(v)
+                    i.connections.forEach((c) => (c.foundLastRound = false))
                     i.saved = true
                     return i
                 }),
@@ -591,7 +594,10 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
                 const discovered = JSON.parse(line) as InstrInfo
                 this.instruments_discovered = true
                 const inst = Instrument.from(discovered)
-                inst.connections[0].status = ConnectionStatus.Active
+                inst.connections.forEach((c) => {
+                    c.foundLastRound = true
+                    c.status = ConnectionStatus.Active
+                })
                 inst.updateStatus()
                 if (inst.info.serial_number && inst.info.model) {
                     this.addOrUpdateInstrument(inst)
@@ -621,7 +627,13 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
                 }
                 for (const i of this._instruments) {
                     for (const c of i.connections) {
-                        if (!c.foundLastRound) {
+                        if (
+                            !c.foundLastRound &&
+                            c.status == ConnectionStatus.Active
+                        ) {
+                            console.error(
+                                "getContent(disc_proc_on_exit()): set status inactive",
+                            )
                             c.status = ConnectionStatus.Inactive
                         }
                     }

--- a/src/instrumentProvider.ts
+++ b/src/instrumentProvider.ts
@@ -151,11 +151,15 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
                     r.friendly_name = instrument.name
                 }
                 if (r.firmware_revision !== instrument.info.firmware_rev) {
-                    if (instrument.info.firmware_rev == "UNKNOWN") { //avoid writing UNKNOWN for firmware revision, instead keep the last known revision in the saved list
-                        Log.warn(`Firmware revision for ${instrument.name} is UNKNOWN, keeping the last known revision ${r.firmware_revision}`, {
-                            file: "instruments.ts",
-                            func: "InstrumentTreeDataProvider.updateSaved()",
-                        })
+                    if (instrument.info.firmware_rev == "UNKNOWN") {
+                        //avoid writing UNKNOWN for firmware revision, instead keep the last known revision in the saved list
+                        Log.warn(
+                            `Firmware revision for ${instrument.name} is UNKNOWN, keeping the last known revision ${r.firmware_revision}`,
+                            {
+                                file: "instruments.ts",
+                                func: "InstrumentTreeDataProvider.updateSaved()",
+                            },
+                        )
                     } else {
                         r.firmware_revision = instrument.info.firmware_rev
                     }
@@ -186,7 +190,11 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
 
         await vscode.workspace
             .getConfiguration("tsp")
-            .update("savedInstruments", unique, vscode.ConfigurationTarget.Global)
+            .update(
+                "savedInstruments",
+                unique,
+                vscode.ConfigurationTarget.Global,
+            )
     }
 
     addOrUpdateInstruments(instruments: Instrument[]) {

--- a/src/instrumentProvider.ts
+++ b/src/instrumentProvider.ts
@@ -546,6 +546,13 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
             func: "InstrumentProvider.getContent()",
         }
         return new Promise((resolve) => {
+            for (const i of this._instruments) {
+                for (const c of i.connections) {
+                    // Set the connection to "not found last round"
+                    c.foundLastRound = false
+                    // This will be set to 'true' as connections are found
+                }
+            }
             const rl = readline.createInterface({
                 input: discovery_proc.stdout,
             })
@@ -587,6 +594,13 @@ export class InstrumentProvider implements VscTdp, vscode.Disposable {
             discovery_proc.on("exit", (code: number) => {
                 if (code) {
                     Log.trace(`Discover Exit Code: ${code}`, LOGLOC)
+                }
+                for (const i of this._instruments) {
+                    for (const c of i.connections) {
+                        if (!c.foundLastRound) {
+                            c.status = ConnectionStatus.Inactive
+                        }
+                    }
                 }
                 resolve(this.instruments_discovered)
             })


### PR DESCRIPTION
- Automatically cull stale instruments if they are not found in this round of discovery
- Refresh the instrument list every 5 seconds, running the discovery process for 4 seconds
- Add `tsp.autorefresh` setting. 
    - Start discovery in the event the setting is enabled (default) 
    - Remove timer for the next discovery run in the event the setting is disabled
 
Resolves: TSP-1262, TSP-1498