### PR TITLE
Fix WebView tools not working after vscode close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 -->
 ## [1.5.2]
 
-### Fixed 
+### Fixed
 - **tsp-toolkit-trigger-flow** - Ensure maximum model limit is not exceeded when using two-model templates
 - Ensure correct instrument information is displayed in the instrument explorer and user settings.json file
 - Fixed issues with recall (after closing the session and recalling) and system configuration changes
+- Fix issue on macOS where closing vscode will make webview tools not work
 
 ### Changed
 - Rename 'Upgrade firmware' to 'Update firmware'.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ import { ExtraActionsWebView } from "./ExtraActionsWebView"
 
 let _instrExplorer: InstrumentsExplorer
 let _tspConverterDiagnostics: vscode.DiagnosticCollection
+let _triggerFlowWebViewManager: TriggerFlowWebViewManager
+let _scriptGenWebViewManager: ScriptGenWebViewManager
 
 /**
  * Represents a contributed TSP Toolkit configuration setting.
@@ -702,8 +704,14 @@ export async function activate(context: vscode.ExtensionContext) {
     triggerFlowDataProvider.setTreeView(treeView)
 
     // Managers use their specific data providers
-    new ScriptGenWebViewManager(context, scriptGenDataProvider)
-    new TriggerFlowWebViewManager(context, triggerFlowDataProvider)
+    _scriptGenWebViewManager = new ScriptGenWebViewManager(
+        context,
+        scriptGenDataProvider,
+    )
+    _triggerFlowWebViewManager = new TriggerFlowWebViewManager(
+        context,
+        triggerFlowDataProvider,
+    )
 
     Log.info("TSP Toolkit activation complete", LOGLOC)
 
@@ -715,6 +723,8 @@ export function deactivate() {
     const LOGLOC = { file: "extensions.ts", func: "deactivate()" }
     Log.info("Deactivating TSP Toolkit", LOGLOC)
     _instrExplorer.dispose()
+    _scriptGenWebViewManager.dispose()
+    _triggerFlowWebViewManager.dispose()
     Log.info("Deactivation complete", LOGLOC)
 }
 

--- a/src/scriptGenWebViewManager.ts
+++ b/src/scriptGenWebViewManager.ts
@@ -17,10 +17,13 @@ import {
  * Script Generation specific session manager
  * Extends BaseSessionManager with Script Generation specific logic
  */
-export class ScriptGenWebViewManager extends BaseSessionManager<
-    ScriptGenDataProvider,
-    SessionTypeTreeItem | SessionInstanceTreeItem
-> {
+export class ScriptGenWebViewManager
+    extends BaseSessionManager<
+        ScriptGenDataProvider,
+        SessionTypeTreeItem | SessionInstanceTreeItem
+    >
+    implements vscode.Disposable
+{
     private readonly storage: GenericSessionStorage
     private readonly validator: SessionNameValidator
 
@@ -62,6 +65,9 @@ export class ScriptGenWebViewManager extends BaseSessionManager<
             "scriptGenSessions",
         )
         this.validator = new SessionNameValidator(this.storage)
+    }
+    dispose() {
+        this.child?.kill()
     }
 
     /**

--- a/src/triggerFlowWebViewManager.ts
+++ b/src/triggerFlowWebViewManager.ts
@@ -17,10 +17,13 @@ import {
  * Trigger Flow specific session manager
  * Extends BaseSessionManager with Trigger Flow specific logic
  */
-export class TriggerFlowWebViewManager extends BaseSessionManager<
-    TriggerFlowDataProvider,
-    SessionTypeTreeItem | SessionInstanceTreeItem
-> {
+export class TriggerFlowWebViewManager
+    extends BaseSessionManager<
+        TriggerFlowDataProvider,
+        SessionTypeTreeItem | SessionInstanceTreeItem
+    >
+    implements vscode.Disposable
+{
     private readonly storage: GenericSessionStorage
     private readonly validator: SessionNameValidator
     private isTrigFlowColdRecall = false
@@ -63,6 +66,9 @@ export class TriggerFlowWebViewManager extends BaseSessionManager<
             "triggerFlowSessions",
         )
         this.validator = new SessionNameValidator(this.storage)
+    }
+    dispose() {
+        this.child?.kill()
     }
 
     /**


### PR DESCRIPTION
- Implement Dispose on all webview managers to kill the webview child-process
- call `dispose()` on webview managers during `deactivate` function

Resolves: TSP-1816