### PR TITLE
Allow username input when authenticating with MP5000 instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Continuously discover instruments by default (disable by setting the `tsp.autorefresh` setting to `false`)
 - **tsp-toolkit-language-interop** - Implement tsp language interop feature
 - Added configurable 'Connection Timeout' as a VS Code setting for instrument connections.
+- Allow username input when authenticating with MP5000 instruments
 
 
 ## [1.5.1]

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -899,14 +899,14 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
             return credentials
         }
 
-        // if (reqs.username) {
-        //     credentials.username = await vscode.window.showInputBox({
-        //         title: "Enter Username",
-        //         placeHolder: "username",
-        //         prompt: "Enter the username for the instrument to which you are trying to connect.",
-        //         ignoreFocusOut: true,
-        //     })
-        // }
+        if (reqs.username) {
+            credentials.username = await vscode.window.showInputBox({
+                title: "Enter Username",
+                placeHolder: "Username -- Leave blank for default user",
+                prompt: "Enter the username for the instrument to which you are trying to connect.",
+                ignoreFocusOut: true,
+            })
+        }
 
         if (reqs.password) {
             credentials.password = await vscode.window.showInputBox({
@@ -956,7 +956,10 @@ export class Connection extends vscode.TreeItem implements vscode.Disposable {
                 return null
             }
 
-            if (credentials.username) {
+            if (
+                credentials.username &&
+                credentials.username.trim().length > 0
+            ) {
                 args.push("--username", credentials.username)
             }
 


### PR DESCRIPTION
- Add placeholder text to make it obvious that you can skip username entry
- Leaving username entry blank will elide username when logging in

Resolves: TSP-1623