### PR TITLE
Allow user to reveal unfocused active session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Ensure correct instrument information is displayed in the instrument explorer and user settings.json file
 - Fixed issues with recall (after closing the session and recalling) and system configuration changes
 - Fix issue on macOS where closing vscode will make webview tools not work
+- Allow user to select Script Gen or Trigger Flow session from tools view and show existing webview
 
 ### Changed
 - Rename 'Upgrade firmware' to 'Update firmware'.

--- a/src/baseSessionManager.ts
+++ b/src/baseSessionManager.ts
@@ -198,6 +198,8 @@ export abstract class BaseSessionManager<TDataProvider, TSessionInstance> {
             this.setupWebviewMessageListener()
             this.setupThemeChangeListener()
             this.setupPanelDisposal()
+        } else {
+            this.panel.reveal()
         }
     }
 


### PR DESCRIPTION
If the user has an unfocused, active Script Gen or TriggerFlow UI session, when they click the session in the tools view, the session will now be revealed. 

Resolves: TSP-1908