### PR TITLE
Update tsp-language-interop types version to get TSP-1874 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
             },
             "devDependencies": {
                 "@istanbuljs/nyc-config-typescript": "^1.0.0",
-                "@tektronix/tsp-language-interop-types": "0.1.0-3",
+                "@tektronix/tsp-language-interop-types": "0.1.0-4",
                 "@types/chai": "4.3.18",
                 "@types/mocha": "10.0.10",
                 "@types/node": "22.10.2",
@@ -62,9 +62,9 @@
                 "@tektronix/trigger-flow-darwin-arm64": "0.2.2-6",
                 "@tektronix/trigger-flow-linux-x64": "0.2.2-6",
                 "@tektronix/trigger-flow-win32-x64": "0.2.2-6",
-                "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-3",
-                "@tektronix/tsp-language-interop-linux-x64": "0.1.0-3",
-                "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-3"
+                "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-4",
+                "@tektronix/tsp-language-interop-linux-x64": "0.1.0-4",
+                "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-4"
             }
         },
         "node_modules/@azu/format-text": {
@@ -1725,9 +1725,9 @@
             }
         },
         "node_modules/@tektronix/tsp-language-interop-darwin-arm64": {
-            "version": "0.1.0-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-darwin-arm64/0.1.0-3/be127e278fb3ab7a3284cca16889d4c1d1edfb97",
-            "integrity": "sha512-PXx1plXzu5i1+NwSlNKIlEKimJIfyDJ/ZGziOL90g7m9PD3bwyJw8ndNm5Tio+2e5DT3jbhQXE4v5ZdYJcS9ag==",
+            "version": "0.1.0-4",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-darwin-arm64/0.1.0-4/1e6ba057d7dff25d21e4b209d867ece2764a9170",
+            "integrity": "sha512-Jb6SpZs++wcS0JQH7LrTENeMdezVXI5UIn+qPL1jOjPb19p4aNrwhqxj6WmWGIgiNS5BH61uqhXY1aCTFTXwqw==",
             "cpu": [
                 "arm64"
             ],
@@ -1737,16 +1737,16 @@
                 "darwin"
             ],
             "dependencies": {
-                "@tektronix/tsp-language-interop-types": "0.1.0-3"
+                "@tektronix/tsp-language-interop-types": "0.1.0-4"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@tektronix/tsp-language-interop-linux-x64": {
-            "version": "0.1.0-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-linux-x64/0.1.0-3/7868f9735a6f3f76aaed1f73b1b3557a4b9b0bbf",
-            "integrity": "sha512-l7i6RwxgNgncgIbjBzdnqu6+G53AAN/ft4/ru+9LakNYPGAHDcmv4uCU35yuGa3xt7VziLlQ3iTqAg1Yxgxepw==",
+            "version": "0.1.0-4",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-linux-x64/0.1.0-4/c3da3e50256adc971fe10e9224a0bbdcc31da5f6",
+            "integrity": "sha512-350i+njZlJnNoMPOLLBW4gZQNd8Nifm2/BH1g4PobX/DlLmU8/+GLa+nmc4ZtQY86fFB8Zn9Gh5ibxRY1UOgqA==",
             "cpu": [
                 "x64"
             ],
@@ -1756,23 +1756,23 @@
                 "linux"
             ],
             "dependencies": {
-                "@tektronix/tsp-language-interop-types": "0.1.0-3"
+                "@tektronix/tsp-language-interop-types": "0.1.0-4"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@tektronix/tsp-language-interop-types": {
-            "version": "0.1.0-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-types/0.1.0-3/cc03fa7dfecd9283fe5ea517ce16eca421eb15eb",
-            "integrity": "sha512-B938/PgRrrUEBIbHdErU+zeUl/AEDk9k+K5/ultBygWmGat77h9NJiRRMto3R2GZT9Rf05NP4/UkitZkXIi7FQ==",
+            "version": "0.1.0-4",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-types/0.1.0-4/39e739f665ddf7530894d02946bb1cde6e96a03a",
+            "integrity": "sha512-3PZji4LAo4tMxpBRRp24P017gNkRtQCguaYEgTd7G+iCdVzU8M66JX31BeYej5+gQXfDttpLGLdW6JaYrZpwFA==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@tektronix/tsp-language-interop-win32-x64": {
-            "version": "0.1.0-3",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-win32-x64/0.1.0-3/7f4bd65697b4db2b8985d09a19c5e391489fde00",
-            "integrity": "sha512-57mSgMT25vWCq51EXf1EgejxQ1DYmouyQxaSddDB4zrKOFjpY7b62dWIEajhgEYSnsREMRlcAGbkiOjt3glODQ==",
+            "version": "0.1.0-4",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-win32-x64/0.1.0-4/f61ff15235d90824af0aad9b3e812eee162e5862",
+            "integrity": "sha512-UYj0idt3RbMmFecRDPbCWTF9GCfNfqd32o0XPMN1CVKfP6y7fJNqCJrkRCzPTYUWvLdrfK+4IT+oxkXr0O+zUQ==",
             "cpu": [
                 "x64"
             ],
@@ -1782,7 +1782,7 @@
                 "win32"
             ],
             "dependencies": {
-                "@tektronix/tsp-language-interop-types": "0.1.0-3"
+                "@tektronix/tsp-language-interop-types": "0.1.0-4"
             },
             "engines": {
                 "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
             },
             "devDependencies": {
                 "@istanbuljs/nyc-config-typescript": "^1.0.0",
-                "@tektronix/tsp-language-interop-types": "0.1.0-2",
+                "@tektronix/tsp-language-interop-types": "0.1.0-3",
                 "@types/chai": "4.3.18",
                 "@types/mocha": "10.0.10",
                 "@types/node": "22.10.2",
@@ -62,9 +62,9 @@
                 "@tektronix/trigger-flow-darwin-arm64": "0.2.2-6",
                 "@tektronix/trigger-flow-linux-x64": "0.2.2-6",
                 "@tektronix/trigger-flow-win32-x64": "0.2.2-6",
-                "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-2",
-                "@tektronix/tsp-language-interop-linux-x64": "0.1.0-2",
-                "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-2"
+                "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-3",
+                "@tektronix/tsp-language-interop-linux-x64": "0.1.0-3",
+                "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-3"
             }
         },
         "node_modules/@azu/format-text": {
@@ -1725,9 +1725,9 @@
             }
         },
         "node_modules/@tektronix/tsp-language-interop-darwin-arm64": {
-            "version": "0.1.0-2",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-darwin-arm64/0.1.0-2/9284b18ff28eff305af9badc635457685d50e585",
-            "integrity": "sha512-Q0SXH0cja1s5Y9dCIQUMfIt/2B728UvGgzyeRe6lCkZE5X34OjVLmn4qsaALlxk91gRUUlaXmke/ClktQF87Tw==",
+            "version": "0.1.0-3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-darwin-arm64/0.1.0-3/be127e278fb3ab7a3284cca16889d4c1d1edfb97",
+            "integrity": "sha512-PXx1plXzu5i1+NwSlNKIlEKimJIfyDJ/ZGziOL90g7m9PD3bwyJw8ndNm5Tio+2e5DT3jbhQXE4v5ZdYJcS9ag==",
             "cpu": [
                 "arm64"
             ],
@@ -1737,16 +1737,16 @@
                 "darwin"
             ],
             "dependencies": {
-                "@tektronix/tsp-language-interop-types": "0.1.0-2"
+                "@tektronix/tsp-language-interop-types": "0.1.0-3"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@tektronix/tsp-language-interop-linux-x64": {
-            "version": "0.1.0-2",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-linux-x64/0.1.0-2/02779ca3cfd21c00f39d6c5c323fcbb907d30234",
-            "integrity": "sha512-7cNbARhD402l1xXEdFsBX9gdhpGdWXGZm0mr6BZzPQEfHVX/3tPTKmI7+ZQ1jsjqbt3rHPKwQxphnXAX4dB4eg==",
+            "version": "0.1.0-3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-linux-x64/0.1.0-3/7868f9735a6f3f76aaed1f73b1b3557a4b9b0bbf",
+            "integrity": "sha512-l7i6RwxgNgncgIbjBzdnqu6+G53AAN/ft4/ru+9LakNYPGAHDcmv4uCU35yuGa3xt7VziLlQ3iTqAg1Yxgxepw==",
             "cpu": [
                 "x64"
             ],
@@ -1756,23 +1756,23 @@
                 "linux"
             ],
             "dependencies": {
-                "@tektronix/tsp-language-interop-types": "0.1.0-2"
+                "@tektronix/tsp-language-interop-types": "0.1.0-3"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@tektronix/tsp-language-interop-types": {
-            "version": "0.1.0-2",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-types/0.1.0-2/ee2a8e41e576e30b7409a889a601e2f6c4bef940",
-            "integrity": "sha512-76QD4UCwvwaAd+1P6tn/gED1yVDAkFHcGTVQKjdOP3wmPFhiQYsR/I7RCVeqrx5ZB8oNkHFyoTvRxTca17l16w==",
+            "version": "0.1.0-3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-types/0.1.0-3/cc03fa7dfecd9283fe5ea517ce16eca421eb15eb",
+            "integrity": "sha512-B938/PgRrrUEBIbHdErU+zeUl/AEDk9k+K5/ultBygWmGat77h9NJiRRMto3R2GZT9Rf05NP4/UkitZkXIi7FQ==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@tektronix/tsp-language-interop-win32-x64": {
-            "version": "0.1.0-2",
-            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-win32-x64/0.1.0-2/42dcde0cdfabd9f47861807561bdef593f4f69b0",
-            "integrity": "sha512-oqo/D+ydiMlSeqeImH4hvafteKkA7T3uSt1/AeXUDvTZxrFcjZP0xwSgzX1lEjiAjhq/No4cclFSxI03l4AP5A==",
+            "version": "0.1.0-3",
+            "resolved": "https://npm.pkg.github.com/download/@tektronix/tsp-language-interop-win32-x64/0.1.0-3/7f4bd65697b4db2b8985d09a19c5e391489fde00",
+            "integrity": "sha512-57mSgMT25vWCq51EXf1EgejxQ1DYmouyQxaSddDB4zrKOFjpY7b62dWIEajhgEYSnsREMRlcAGbkiOjt3glODQ==",
             "cpu": [
                 "x64"
             ],
@@ -1782,7 +1782,7 @@
                 "win32"
             ],
             "dependencies": {
-                "@tektronix/tsp-language-interop-types": "0.1.0-2"
+                "@tektronix/tsp-language-interop-types": "0.1.0-3"
             },
             "engines": {
                 "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -820,7 +820,7 @@
         "copy-static": "copyfiles -u 1 src/**/*.{js,css} out"
     },
     "devDependencies": {
-        "@tektronix/tsp-language-interop-types": "0.1.0-2",
+        "@tektronix/tsp-language-interop-types": "0.1.0-3",
         "@istanbuljs/nyc-config-typescript": "^1.0.0",
         "@types/chai": "4.3.18",
         "@types/mocha": "10.0.10",
@@ -861,9 +861,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-2",
-        "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-2",
-        "@tektronix/tsp-language-interop-linux-x64": "0.1.0-2",
+        "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-3",
+        "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-3",
+        "@tektronix/tsp-language-interop-linux-x64": "0.1.0-3",
         "@tektronix/kic-cli-darwin-arm64": "0.23.0-1",
         "@tektronix/kic-cli-linux-x64": "0.23.0-1",
         "@tektronix/kic-cli-win32-x64": "0.23.0-1",

--- a/package.json
+++ b/package.json
@@ -820,7 +820,7 @@
         "copy-static": "copyfiles -u 1 src/**/*.{js,css} out"
     },
     "devDependencies": {
-        "@tektronix/tsp-language-interop-types": "0.1.0-3",
+        "@tektronix/tsp-language-interop-types": "0.1.0-4",
         "@istanbuljs/nyc-config-typescript": "^1.0.0",
         "@types/chai": "4.3.18",
         "@types/mocha": "10.0.10",
@@ -861,9 +861,9 @@
         "xml-js": "1.6.11"
     },
     "optionalDependencies": {
-        "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-3",
-        "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-3",
-        "@tektronix/tsp-language-interop-linux-x64": "0.1.0-3",
+        "@tektronix/tsp-language-interop-win32-x64": " 0.1.0-4",
+        "@tektronix/tsp-language-interop-darwin-arm64": " 0.1.0-4",
+        "@tektronix/tsp-language-interop-linux-x64": "0.1.0-4",
         "@tektronix/kic-cli-darwin-arm64": "0.23.0-1",
         "@tektronix/kic-cli-linux-x64": "0.23.0-1",
         "@tektronix/kic-cli-win32-x64": "0.23.0-1",

--- a/src/tspConverter.ts
+++ b/src/tspConverter.ts
@@ -70,7 +70,7 @@ export async function convertTspToPython(
     try {
         result = converter.convertTspToPython(source, {
             className,
-            scriptPath: fileUri.fsPath,
+            // scriptPath: fileUri.fsPath, // Commented out for now, will re-enable once the setting is available
         })
     } catch (err) {
         vscode.window.showErrorMessage(


### PR DESCRIPTION
Update tsp-language-interop types to version 0.1.0-4